### PR TITLE
Remove remaining references to "relay"

### DIFF
--- a/filter/filter.go
+++ b/filter/filter.go
@@ -233,9 +233,9 @@ func (f *filter) startStatistician() {
 	// This goroutine is responsible for monitoring the statistics and
 	// sending it to the monitoring backend.
 
-	totalLine := lineformatter.New("relay_stat_filter", nil,
+	totalLine := lineformatter.New("spout_stat_filter", nil,
 		"passed", "processed", "rejected")
-	ruleLine := lineformatter.New("relay_stat_filter_rule",
+	ruleLine := lineformatter.New("spout_stat_filter_rule",
 		[]string{"rule"}, "triggered")
 
 	for {

--- a/filter/filter_medium_test.go
+++ b/filter/filter_medium_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/jumptrading/influx-spout/config"
-	"github.com/jumptrading/influx-spout/relaytest"
+	"github.com/jumptrading/influx-spout/spouttest"
 )
 
 const natsPort = 44446
@@ -51,7 +51,7 @@ func TestMain(m *testing.M) {
 }
 
 func runMain(m *testing.M) int {
-	s := relaytest.RunGnatsd(natsPort)
+	s := spouttest.RunGnatsd(natsPort)
 	defer s.Shutdown()
 
 	// start the listener with this config
@@ -114,12 +114,12 @@ goodbye,host=gopher01
 
 	// Receive total stats
 	assertReceived(t, statsCh, "stats", `
-relay_stat_filter passed=2,processed=3,rejected=1
+spout_stat_filter passed=2,processed=3,rejected=1
 `)
 
 	// Receive rule specific stats
 	assertReceived(t, statsCh, "rule stats", `
-relay_stat_filter_rule,rule=hello-subject triggered=2
+spout_stat_filter_rule,rule=hello-subject triggered=2
 `)
 }
 
@@ -128,7 +128,7 @@ func assertReceived(t *testing.T, ch <-chan string, label, expected string) {
 	select {
 	case received := <-ch:
 		assert.Equal(t, expected, received)
-	case <-time.After(relaytest.LongWait):
+	case <-time.After(spouttest.LongWait):
 		t.Fatal("timed out waiting for " + label)
 	}
 }

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -146,7 +146,7 @@ func (l *listener) setupBuffers() int {
 	return bufSize
 }
 
-var notifyLine = lineformatter.New("relay_mon", nil, "type", "state", "pid")
+var notifyLine = lineformatter.New("spout_mon", nil, "type", "state", "pid")
 
 func (l *listener) notifyState(state string) {
 	line := notifyLine.Format(nil, "listener", state, os.Getpid())
@@ -213,7 +213,7 @@ func (l *listener) handleNatsError(err error) {
 
 func (l *listener) startStatistician(stop <-chan struct{}) {
 	statsLine := lineformatter.New(
-		"relay_stat_listener", nil,
+		"spout_stat_listener", nil,
 		"received",
 		"sent",
 		"read_errors",

--- a/listener/listener_medium_test.go
+++ b/listener/listener_medium_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/jumptrading/influx-spout/config"
-	"github.com/jumptrading/influx-spout/relaytest"
+	"github.com/jumptrading/influx-spout/spouttest"
 )
 
 const (
@@ -58,7 +58,7 @@ func TestMain(m *testing.M) {
 }
 
 func runMain(m *testing.M) int {
-	s := relaytest.RunGnatsd(natsPort)
+	s := spouttest.RunGnatsd(natsPort)
 	defer s.Shutdown()
 	return m.Run()
 }
@@ -92,7 +92,7 @@ func TestBatching(t *testing.T) {
 	select {
 	case <-newMsg:
 		break
-	case <-time.After(relaytest.LongWait):
+	case <-time.After(spouttest.LongWait):
 		t.Fatal("failed to see message")
 	}
 
@@ -100,7 +100,7 @@ func TestBatching(t *testing.T) {
 	select {
 	case <-newMsg:
 		t.Fatal("unexpectedly saw message")
-	case <-time.After(relaytest.ShortWait):
+	case <-time.After(spouttest.ShortWait):
 	}
 }
 
@@ -149,7 +149,7 @@ func TestBatchBufferFull(t *testing.T) {
 	conn := dialListener(t)
 	defer conn.Close()
 	msg := make([]byte, 100)
-	timeout := time.After(relaytest.LongWait)
+	timeout := time.After(spouttest.LongWait)
 	writeCount := 0
 loop:
 	for {
@@ -176,7 +176,7 @@ loop:
 	select {
 	case <-newMsg:
 		t.Fatal("message unexpectedly seen")
-	case <-time.After(relaytest.ShortWait):
+	case <-time.After(spouttest.ShortWait):
 		return
 	}
 }
@@ -210,8 +210,8 @@ func TestStatistician(t *testing.T) {
 	// Look for expected stats
 	select {
 	case received := <-statsCh:
-		assert.Equal(t, "relay_stat_listener received=3,sent=2,read_errors=1\n", received)
-	case <-time.After(relaytest.LongWait):
+		assert.Equal(t, "spout_stat_listener received=3,sent=2,read_errors=1\n", received)
+	case <-time.After(spouttest.LongWait):
 		t.Fatal("no message seen")
 	}
 

--- a/spouttest/gnats.go
+++ b/spouttest/gnats.go
@@ -12,17 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package relaytest
+package spouttest
 
-import "time"
+import (
+	"github.com/nats-io/gnatsd/server"
+	"github.com/nats-io/gnatsd/test"
+)
 
-// LongWait should be used in tests when waiting for events that are
-// expected to happen. It is quite long to account for slow/busy test
-// hosts. Typically only a fraction of this time is actually used,
-// unless something is broken.
-const LongWait = 10 * time.Second
-
-// ShortWait should be used in tests when checking for events that are
-// expected *not* to happen. A test will block for this long, unless
-// something is broken.
-const ShortWait = 50 * time.Millisecond
+// RunGnatsd runs a gnatsd server on the specified port for testing
+// against.
+//
+// This is essentially a copy of the unexported RunServerOnPort()
+// in github.com/nats-io/go-nats/test
+func RunGnatsd(port int) *server.Server {
+	opts := test.DefaultTestOptions
+	opts.Port = port
+	return test.RunServer(&opts)
+}

--- a/spouttest/waits.go
+++ b/spouttest/waits.go
@@ -12,20 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package relaytest
+package spouttest
 
-import (
-	"github.com/nats-io/gnatsd/server"
-	"github.com/nats-io/gnatsd/test"
-)
+import "time"
 
-// RunGnatsd runs a gnatsd server on the specified port for testing
-// against.
-//
-// This is essentially a copy of the unexported RunServerOnPort()
-// in github.com/nats-io/go-nats/test
-func RunGnatsd(port int) *server.Server {
-	opts := test.DefaultTestOptions
-	opts.Port = port
-	return test.RunServer(&opts)
-}
+// LongWait should be used in tests when waiting for events that are
+// expected to happen. It is quite long to account for slow/busy test
+// hosts. Typically only a fraction of this time is actually used,
+// unless something is broken.
+const LongWait = 10 * time.Second
+
+// ShortWait should be used in tests when checking for events that are
+// expected *not* to happen. A test will block for this long, unless
+// something is broken.
+const ShortWait = 50 * time.Millisecond

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -312,7 +312,7 @@ func (w *Writer) startStatistician() {
 	// This goroutine is responsible for monitoring the statistics and
 	// sending it to the monitoring backend.
 	statsLine := lineformatter.New(
-		"relay_stat_writer", nil,
+		"spout_stat_writer", nil,
 		"received",
 		"write_requests",
 		"failed_writes",
@@ -333,7 +333,7 @@ func (w *Writer) startStatistician() {
 	}
 }
 
-var notifyLine = lineformatter.New("relay_mon", nil, "type", "state", "pid")
+var notifyLine = lineformatter.New("spout_mon", nil, "type", "state", "pid")
 
 func (w *Writer) notifyState(state string) {
 	line := notifyLine.Format(nil, "writer", state, os.Getpid())

--- a/writer/writer_medium_test.go
+++ b/writer/writer_medium_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/jumptrading/influx-spout/config"
-	"github.com/jumptrading/influx-spout/relaytest"
+	"github.com/jumptrading/influx-spout/spouttest"
 )
 
 var httpWrites = make(chan string, 10)
@@ -65,7 +65,7 @@ func runMain(m *testing.M) int {
 	var err error
 
 	// Start gnatsd.
-	s := relaytest.RunGnatsd(natsPort)
+	s := spouttest.RunGnatsd(natsPort)
 	defer s.Shutdown()
 
 	// Set up a dummy HTTP server to write to.
@@ -105,7 +105,7 @@ func TestBasicWriter(t *testing.T) {
 	publish(t, subject, "And by opposing end them. To die: to sleep;")
 
 	// wait for confirmation that they were written
-	timeout := time.After(relaytest.LongWait)
+	timeout := time.After(spouttest.LongWait)
 	for i := 0; i < 5; i++ {
 		select {
 		case <-httpWrites:
@@ -140,7 +140,7 @@ func TestBatchMBLimit(t *testing.T) {
 	select {
 	case msg := <-httpWrites:
 		assert.Len(t, msg, totalSize)
-	case <-time.After(relaytest.LongWait):
+	case <-time.After(spouttest.LongWait):
 		t.Fatal("timed out waiting for messages")
 	}
 	assertNoWrite(t)
@@ -243,7 +243,7 @@ func assertWrite(t *testing.T, expected string) {
 	select {
 	case msg := <-httpWrites:
 		assert.Equal(t, msg, expected)
-	case <-time.After(relaytest.LongWait):
+	case <-time.After(spouttest.LongWait):
 		t.Fatal("timed out waiting for message")
 	}
 }
@@ -252,6 +252,6 @@ func assertNoWrite(t *testing.T) {
 	select {
 	case msg := <-httpWrites:
 		t.Fatalf("saw unexpected write: %q", msg)
-	case <-time.After(relaytest.ShortWait):
+	case <-time.After(spouttest.ShortWait):
 	}
 }


### PR DESCRIPTION
The old "relay" name still existed in the code. For consistency these have all been changes to "spout".

**COMPATIBILITY NOTE**: This changes the metrics names published to the NATS monitor subject.