### PR TITLE
writer: Fix batch writing when filter rules exist

### DIFF
--- a/writer/writer.go
+++ b/writer/writer.go
@@ -222,7 +222,7 @@ func (w *Writer) getBatchWriteFunc(batch *batchBuffer) func([]byte) {
 		// filters.
 		for _, line := range bytes.SplitAfter(data, []byte("\n")) {
 			if w.filterLine(line) {
-				batchWrite(data)
+				batchWrite(line)
 			}
 		}
 	}

--- a/writer/writer_medium_test.go
+++ b/writer/writer_medium_test.go
@@ -180,6 +180,22 @@ func TestBasicFilterRule(t *testing.T) {
 	assertNoWrite(t)
 }
 
+func TestBatchedInput(t *testing.T) {
+	conf := testConfig()
+	conf.Rule = []config.Rule{{
+		Rtype: "basic",
+		Match: "foo",
+	}}
+	w := startWriter(t, conf)
+	defer w.Stop()
+
+	// Send 2 messages together, the first of which should be dropped.
+	publish(t, conf.NATSSubject[0], "should be dropped\nfoo bar")
+
+	assertWrite(t, "foo bar")
+	assertNoWrite(t)
+}
+
 func TestRegexFilterRule(t *testing.T) {
 	conf := testConfig()
 	conf.Rule = []config.Rule{{


### PR DESCRIPTION
Don't send the entire input for each line that matches a filter rule!

Fixes #5.