### PR TITLE
filter: Restructure for testability

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,12 +68,14 @@ func main() {
 	}
 
 	switch c.Mode {
-	case "filter":
-		filter.StartFilter(c)
 	case "listener":
 		listener.StartListener(c)
 	case "listener_http":
 		listener.StartHTTPListener(c)
+	case "filter":
+		if _, err := filter.StartFilter(c); err != nil {
+			log.Fatalf("failed to start writer: %v", err)
+		}
 	case "writer":
 		if c.WriterWorkers == 0 {
 			// this seems to be an okay default from our testing experience:

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -55,7 +55,7 @@ type Writer struct {
 	batchMaxBytes int
 	batchMaxAge   time.Duration
 	nc            *nats.Conn
-	rules         []filter.FilterRule
+	rules         []filter.Rule
 	stats         *stats.Stats
 	wg            sync.WaitGroup
 	stop          chan struct{}
@@ -160,7 +160,7 @@ func (w *Writer) Stop() {
 }
 
 // GetRules implements filter.Filtering.
-func (w *Writer) GetRules() []filter.FilterRule {
+func (w *Writer) GetRules() []filter.Rule {
 	return w.rules
 }
 


### PR DESCRIPTION
While working for an end-to-end test for influx-spout it became apparent that the current way the filter is started makes it difficult to test.

The main change here is that StartFilter now returns a Filter instance instead of calling runtime.Goexit() and Filter now has Stop() method which cleans up the filter. This makes it possible to shutdown a Filter once it has been started, making it much easier to work with.

This is very similar to how the writer is already structured.

Also here:
- Simplified the "medium" filter tests, taking advantage of the new StartFilter/Stop structure. A dodgy 1s sleep could now be removed.
- Unexported a number of types and methods that weren't being used externally (and never will be).
- Added docstrings to all exported types and methods.
- Renamed filter.FilterRule to just filter.Rule to avoid stuttering.

A similar change for the listener is coming.