### PR TITLE
Added the listener name to stats

### DIFF
--- a/listener/listener.go
+++ b/listener/listener.go
@@ -219,14 +219,17 @@ func (l *listener) handleNatsError(err error) {
 
 func (l *listener) startStatistician(stop <-chan struct{}) {
 	statsLine := lineformatter.New(
-		"spout_stat_listener", nil,
+		"spout_stat_listener",
+		[]string{"listener"},
 		"received",
 		"sent",
 		"read_errors",
 	)
+	tagVals := []string{l.c.Name}
 	for {
 		stats := l.stats.Clone() // Sample counts
-		l.nc.Publish(l.c.NATSSubjectMonitor, statsLine.Format(nil,
+		l.nc.Publish(l.c.NATSSubjectMonitor, statsLine.Format(
+			tagVals,
 			stats.Get(linesReceived),
 			stats.Get(batchesSent),
 			stats.Get(readErrors),

--- a/listener/listener_medium_test.go
+++ b/listener/listener_medium_test.go
@@ -45,6 +45,7 @@ var (
 func testConfig() *config.Config {
 	return &config.Config{
 		Mode:               "listener",
+		Name:               "testlistener",
 		NATSAddress:        natsAddress,
 		NATSSubject:        []string{natsSubject},
 		NATSSubjectMonitor: natsSubject + "-monitor",
@@ -210,7 +211,7 @@ func TestStatistician(t *testing.T) {
 	// Look for expected stats
 	select {
 	case received := <-statsCh:
-		assert.Equal(t, "spout_stat_listener received=3,sent=2,read_errors=1\n", received)
+		assert.Equal(t, "spout_stat_listener,listener=testlistener received=3,sent=2,read_errors=1\n", received)
 	case <-time.After(spouttest.LongWait):
 		t.Fatal("no message seen")
 	}


### PR DESCRIPTION
We may have multiple listeners running on the same host so this will help us differentiate between them. 