### PR TITLE
Test with Go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 go:
   - 1.8.x
   - 1.9.x
-  - 1.10.x
+  - "1.10"
   - master  # find out if a upcoming change in Go is going to break us
 
 # No need for an install step as all dependencies are vendored.


### PR DESCRIPTION
v1.10 of Go is now officially released so we should be testing against it.