### PR TITLE
filter: Changed NATS import to use the correct path

### DIFF
--- a/filter/filter.go
+++ b/filter/filter.go
@@ -25,7 +25,7 @@ import (
 	"github.com/jumptrading/influx-spout/config"
 	"github.com/jumptrading/influx-spout/lineformatter"
 	"github.com/jumptrading/influx-spout/stats"
-	"github.com/nats-io/nats"
+	"github.com/nats-io/go-nats"
 )
 
 // Name for supported stats


### PR DESCRIPTION
The alias `/nats` breaks the build in a vanilla environment as that isn't vendored in.