### PR TITLE
Update TravisCI badge now that project is public

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# influx-spout [![Build Status](https://travis-ci.com/jumptrading/influx-spout.svg?token=tnGgsxkjnTL4Es3TAsMc&branch=master)](https://travis-ci.com/jumptrading/influx-spout) [![Go Report Card](https://goreportcard.com/badge/github.com/jumptrading/influx-spout)](https://goreportcard.com/report/github.com/jumptrading/influx-spout)
+# influx-spout [![Build Status](https://travis-ci.org/jumptrading/influx-spout.svg?branch=master)](https://travis-ci.org/jumptrading/influx-spout) [![Go Report Card](https://goreportcard.com/badge/github.com/jumptrading/influx-spout)](https://goreportcard.com/report/github.com/jumptrading/influx-spout)
 
 ## Overview
 


### PR DESCRIPTION
I noticed that the TravisCI badge was no longer correct since the repo became public.