### PR TITLE
perfcheck: Fetch reference branch in reference clone

### DIFF
--- a/perfcheck
+++ b/perfcheck
@@ -47,9 +47,6 @@ reference_bench_output="$PWD/reference.bench"
 title "Building benchcheck tool"
 go build -o benchcheck/benchcheck ./benchcheck || exit 1
 
-title "Fetching upstream reference branch"
-git fetch --depth=50 origin perfcheck-reference
-
 title "Setting up reference branch"
 
 # Create a temporary GOPATH which gets removed on exit.
@@ -64,6 +61,11 @@ set -e
 clone_dir=$ref_gopath/src/$GO_PACKAGE
 git clone --quiet . $clone_dir
 pushd $clone_dir > /dev/null
+
+title "Fetching upstream reference branch"
+git remote add upstream https://github.com/jumptrading/influx-spout.git
+git fetch --depth=10 upstream perfcheck-reference
+
 git checkout --quiet -b perfcheck $REFERENCE_REVISION > /dev/null
 popd > /dev/null
 set +e


### PR DESCRIPTION
The reference revision fetched in the "current" repo didn't always make it across when cloning to the reference repo, resulting in "reference is not a tree" errors from git.