### PR TITLE
perfcheck tweaks

### DIFF
--- a/benchcheck/benchcheck.go
+++ b/benchcheck/benchcheck.go
@@ -67,18 +67,16 @@ func main() {
 		log.Fatal(err)
 	}
 
-	if hasProblem {
-		fmt.Println("Performance regression found!")
-		fmt.Println()
+	if hasProblem || *flagPrint {
 		printTables(tables)
-	} else if *flagPrint {
-		printTables(tables)
-	} else {
-		fmt.Println("No performance regressions found")
 	}
+	fmt.Println()
 
 	if hasProblem {
+		fmt.Println("Performance regression found!")
 		os.Exit(1)
+	} else {
+		fmt.Println("No performance regressions found.")
 	}
 }
 

--- a/perfcheck
+++ b/perfcheck
@@ -96,5 +96,5 @@ for a in `seq $max_attempts`; do
     done
 
     title "Comparing benchmarks"
-    ./benchcheck/benchcheck $reference_bench_output $current_bench_output && exit 0
+    ./benchcheck/benchcheck -print $reference_bench_output $current_bench_output && exit 0
 done

--- a/perfcheck
+++ b/perfcheck
@@ -3,7 +3,8 @@
 GO_PACKAGE=github.com/jumptrading/influx-spout
 REFERENCE_REVISION=${REFERENCE_REVISION:-aa46d4677bb8ef72848c211312d9051b879322dc}
 
-iterations=5
+max_attempts=3
+iterations=3
 orig_gopath=$GOPATH
 
 echo "Comparing working tree against $REFERENCE_REVISION"
@@ -70,25 +71,30 @@ git checkout --quiet -b perfcheck $REFERENCE_REVISION > /dev/null
 popd > /dev/null
 set +e
 
-# Remove output from previous runs
-rm -f $reference_bench_output $current_bench_output
 
 # Run the tests for the current benchmarks and reference benchmarks
 # $iterations times. The runs are interleaved to minimise the effects
 # of other load on the host.
-for i in `seq $iterations`; do
-    title "Iteration $i/$iterations"
+for a in `seq $max_attempts`; do
+    title "Attempt $a ($max_attempts max)"
 
-    title "Running current benchmarks"
-    export GOPATH=$orig_gopath
-    capture_benchmarks "$test_sizes" $current_bench_output
+    # Remove output from previous runs
+    rm -f $reference_bench_output $current_bench_output
 
-    title "Running reference benchmarks"
-    export GOPATH=$ref_gopath
-    pushd $clone_dir > /dev/null
-    capture_benchmarks "$test_sizes" $reference_bench_output
-    popd > /dev/null
+    for i in `seq $iterations`; do
+        title "Iteration $i/$iterations"
+
+        title "Running current benchmarks"
+        export GOPATH=$orig_gopath
+        capture_benchmarks "$test_sizes" $current_bench_output
+
+        title "Running reference benchmarks"
+        export GOPATH=$ref_gopath
+        pushd $clone_dir > /dev/null
+        capture_benchmarks "$test_sizes" $reference_bench_output
+        popd > /dev/null
+    done
+
+    title "Comparing benchmarks"
+    ./benchcheck/benchcheck $reference_bench_output $current_bench_output && exit 0
 done
-
-title "Comparing benchmarks"
-./benchcheck/benchcheck $reference_bench_output $current_bench_output


### PR DESCRIPTION
To mitigate against the variation in performance in TravisCI's test environment, perfcheck will now try multiple attempts at passing. Each attempt is 3 iterations of benchmark runs.

This increases the chances of success and makes the overall test run time shorter if the first attempt passes.

perfcheck now also has benchcheck print the results table. While we're working through perfcheck changes it's useful to always see the benchmark comparison from benchcheck.
