### PR TITLE
New writer max_pending metric

### DIFF
--- a/stats/stats.go
+++ b/stats/stats.go
@@ -60,6 +60,22 @@ func (s *Stats) Inc(name string) int {
 	return s.counts[name]
 }
 
+// Max updates a counter if the value supplied is greater than the
+// previous one. It panics if the name is not valid.
+func (s *Stats) Max(name string, newVal int) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	val, ok := s.counts[name]
+	if !ok {
+		panic(fmt.Sprintf("unknown stat: %q", name))
+	}
+	if newVal > val {
+		s.counts[name] = newVal
+		return newVal
+	}
+	return val
+}
+
 // CounterPair holds the and value for one Stats counter at a given
 // point in time.
 type CounterPair struct {

--- a/stats/stats_small_test.go
+++ b/stats/stats_small_test.go
@@ -41,11 +41,29 @@ func TestBasics(t *testing.T) {
 	assert.Equal(t, 0, s.Get("bar"))
 }
 
+func TestMax(t *testing.T) {
+	s := stats.New("foo")
+
+	assert.Equal(t, 0, s.Get("foo"))
+	assert.Equal(t, 0, s.Max("foo", 0))
+	assert.Equal(t, 0, s.Get("foo"))
+
+	assert.Equal(t, 4, s.Max("foo", 4))
+	assert.Equal(t, 4, s.Get("foo"))
+
+	assert.Equal(t, 4, s.Max("foo", 3))
+	assert.Equal(t, 4, s.Get("foo"))
+
+	assert.Equal(t, 5, s.Max("foo", 5))
+	assert.Equal(t, 5, s.Get("foo"))
+}
+
 func TestInvalid(t *testing.T) {
 	s := stats.New("foo")
 
 	assert.Panics(t, func() { s.Get("bar") })
 	assert.Panics(t, func() { s.Inc("bar") })
+	assert.Panics(t, func() { s.Max("bar", 1) })
 	assert.Equal(t, 0, s.Get("foo"))
 }
 


### PR DESCRIPTION
This metric reports the maximum number of pending bytes observed across all a writer's NATS subscriptions. This can be used to help tune the `nats_pending_max_mb` configuration option.

To assist with generating this metric `stats.Stats` now supports tracking of maximum values.

Closes #31.