### PR TITLE
Always retry connections to NATS

### DIFF
--- a/filter/filter.go
+++ b/filter/filter.go
@@ -101,7 +101,7 @@ func StartFilter(conf *config.Config) (_ *Filter, err error) {
 }
 
 func (f *Filter) natsConnect() (natsConn, error) {
-	nc, err := nats.Connect(f.c.NATSAddress)
+	nc, err := nats.Connect(f.c.NATSAddress, nats.MaxReconnects(-1))
 	if err != nil {
 		return nil, fmt.Errorf("NATS: failed to connect: %v", err)
 	}

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -139,12 +139,10 @@ func newListener(c *config.Config) (*Listener, error) {
 		batchSizeThreshold: c.ListenerBatchBytes - udpMaxDatagramSize,
 	}
 
-	nc, err := nats.Connect(l.c.NATSAddress)
+	nc, err := nats.Connect(l.c.NATSAddress, nats.MaxReconnects(-1))
 	if err != nil {
 		return nil, err
 	}
-	// If we disconnect, we want to try reconnecting as many times as we can.
-	nc.Opts.MaxReconnect = -1
 	l.nc = nc
 
 	return l, nil

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -99,7 +99,7 @@ func (m *Monitor) Stop() {
 }
 
 func (m *Monitor) natsConnect() (*nats.Conn, error) {
-	nc, err := nats.Connect(m.c.NATSAddress)
+	nc, err := nats.Connect(m.c.NATSAddress, nats.MaxReconnects(-1))
 	if err != nil {
 		return nil, fmt.Errorf("NATS: failed to connect: %v", err)
 	}

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -80,14 +80,10 @@ func StartWriter(c *config.Config) (_ *Writer, err error) {
 		return nil, err
 	}
 
-	w.nc, err = nats.Connect(c.NATSAddress)
+	w.nc, err = nats.Connect(c.NATSAddress, nats.MaxReconnects(-1))
 	if err != nil {
 		return nil, fmt.Errorf("NATS Error: can't connect: %v", err)
 	}
-
-	// if we disconnect, we want to try reconnecting as many times as
-	// we can
-	w.nc.Opts.MaxReconnect = -1
 
 	http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost = 100
 


### PR DESCRIPTION
The NATS connections created by the filter and monitor weren't set to keep retrying and were using the default reconnection limit of 60.

The listener and writer were using infinite NATS reconnection attempts but were setting this up in an undocumented way (which may not always have worked).