### PR TITLE
listener: Add `failed_nats_publish` metric

### DIFF
--- a/listener/listener_medium_test.go
+++ b/listener/listener_medium_test.go
@@ -299,6 +299,7 @@ func assertMonitor(t *testing.T, monitorCh chan string, received, sent int) {
 		fmt.Sprintf(`received{component="listener",name="testlistener"} %d`, received),
 		fmt.Sprintf(`sent{component="listener",name="testlistener"} %d`, sent),
 		`read_errors{component="listener",name="testlistener"} 0`,
+		`failed_nats_publish{component="listener",name="testlistener"} 0`,
 	}
 	spouttest.AssertMonitor(t, monitorCh, expected)
 }

--- a/spouttest/e2e_test.go
+++ b/spouttest/e2e_test.go
@@ -131,6 +131,7 @@ func TestEndToEnd(t *testing.T) {
 	// Check metrics published by monitor component.
 	expectedMetrics := regexp.MustCompile(`
 failed_nats_publish{component="filter",name="filter"} 0
+failed_nats_publish{component="listener",name="listener"} 0
 failed_writes{component="writer",influxdb_address="localhost",influxdb_dbname="test",influxdb_port="44501",name="writer"} 0
 invalid_time{component="filter",name="filter"} 0
 max_pending{component="writer",influxdb_address="localhost",influxdb_dbname="test",influxdb_port="44501",name="writer"} \d+


### PR DESCRIPTION
This increments if the listener fails to publish lines to NATS (for consumption by the filter).

Closes #19 .