### PR TITLE
filter: Allow for multiple filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,8 +183,10 @@ nats_subject_monitor = "influx-spout-monitor"
 
 ### Filter
 
-The filter is responsible for filtering measurements published to NATS by the
-listener, and forwarding them on to other NATS subjects.
+The filter is responsible for filtering measurements published to NATS
+by the listener, and forwarding them on to other NATS
+subjects. Multiple filters may be run to distribute the filtering
+workload across machines.
 
 The supported configuration options for the filter mode follow. Defaults are
 shown.


### PR DESCRIPTION
The filter now subscribes to its inbound NATS subject using a queue group so that multiple filters can be run at the same time.

Closes #55.

I've tested this with parallel filters, ensuring that all lines injected into the listener make it through to the database exactly once.