### PR TITLE
Expose k8s probe endpoints for all components

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ read_buffer_bytes = 4194304
 # The listener will publish its own metrics to this NATS subject (for consumption
 # by the monitor).
 nats_subject_monitor = "influx-spout-monitor"
+
+# The listener will serve Kubernetes liveness and readiness probes on this port
+# at /healthz and /readyz. Set to 0 (the default) to disable probes support.
+probe_port = 0
 ```
 
 ### HTTP Listener
@@ -179,6 +183,10 @@ listener_batch_bytes = 1048576
 # The HTTP listener will publish its own metrics to this NATS subject (for
 # consumption by the monitor).
 nats_subject_monitor = "influx-spout-monitor"
+
+# The HTTP listener will serve Kubernetes liveness and readiness probes on this
+# port at /healthz and /readyz. Set to 0 (the default) to disable probes support.
+probe_port = 0
 ```
 
 ### Filter
@@ -215,6 +223,10 @@ nats_pending_max_mb = 200
 
 # The number of filter workers to spawn.
 workers = 8
+
+# The filter will serve Kubernetes liveness and readiness probes on this port at
+# /healthz and /readyz. Set to 0 (the default) to disable probes support.
+probe_port = 0
 
 # Incoming metrics with timestamps ± this value from the current time will be
 # rejected. Metrics with timestamps that are significantly different from previously
@@ -324,6 +336,10 @@ nats_pending_max_mb = 200
 # The writer will publish its own metrics to this NATS subject (for consumption
 # by the monitor).
 nats_subject_monitor = "influx-spout-monitor"
+
+# The writer will serve Kubernetes liveness and readiness probes on this port at
+# /healthz and /readyz. Set to 0 (the default) to disable probes support.
+probe_port = 0
 ```
 
 A writer will batch up messages until one of the limits defined by the
@@ -356,6 +372,10 @@ nats_subject_monitor = "influx-spout-monitor"
 
 # The TCP port where the monitor will serve Prometheus formatted metrics over HTTP.
 port = 9331
+
+# The monitor will serve Kubernetes liveness and readiness probes on this port
+# at /healthz and /readyz. Set to 0 (the default) to disable probes support.
+probe_port = 0
 ```
 
 ## Running tests

--- a/config/config.go
+++ b/config/config.go
@@ -51,6 +51,7 @@ type Config struct {
 	ListenerBatchBytes  int      `toml:"listener_batch_bytes"`
 	Rule                []Rule   `toml:"rule"`
 	MaxTimeDeltaSecs    int      `toml:"max_time_delta_secs"`
+	ProbePort           int      `toml:"probe_port"`
 	Debug               bool     `toml:"debug"`
 }
 
@@ -79,6 +80,7 @@ func newDefaultConfig() *Config {
 		NATSPendingMaxMB:    200,
 		ListenerBatchBytes:  1024 * 1024,
 		MaxTimeDeltaSecs:    600,
+		ProbePort:           0,
 	}
 }
 

--- a/config/config_small_test.go
+++ b/config/config_small_test.go
@@ -55,6 +55,8 @@ read_buffer_bytes = 43210
 nats_pending_max_mb = 100
 listener_batch_bytes = 4096
 max_time_delta_secs = 789
+
+probe_port = 6789
 `
 	conf, err := parseConfig(validConfigSample)
 	require.NoError(t, err, "Couldn't parse a valid config: %v\n", err)
@@ -79,6 +81,8 @@ max_time_delta_secs = 789
 	assert.Equal(t, "spout", conf.NATSSubject[0], "Subject must match")
 	assert.Equal(t, "spout-monitor", conf.NATSSubjectMonitor, "Monitor subject must match")
 	assert.Equal(t, "nats://localhost:4222", conf.NATSAddress, "Address must match")
+
+	assert.Equal(t, 6789, conf.ProbePort)
 }
 
 func TestAllDefaults(t *testing.T) {
@@ -104,6 +108,7 @@ func TestAllDefaults(t *testing.T) {
 	assert.Equal(t, 200, conf.NATSPendingMaxMB)
 	assert.Equal(t, 1048576, conf.ListenerBatchBytes)
 	assert.Equal(t, 600, conf.MaxTimeDeltaSecs)
+	assert.Equal(t, 0, conf.ProbePort)
 	assert.Equal(t, false, conf.Debug)
 	assert.Len(t, conf.Rule, 0)
 }

--- a/filter/filter_medium_test.go
+++ b/filter/filter_medium_test.go
@@ -178,6 +178,9 @@ func TestInvalidTimeStamps(t *testing.T) {
 func startFilter(t *testing.T, conf *config.Config) *Filter {
 	filter, err := StartFilter(conf)
 	require.NoError(t, err)
-	spouttest.AssertReadyProbe(t, conf.ProbePort)
+	if !spouttest.CheckReadyProbe(conf.ProbePort) {
+		filter.Stop()
+		t.Fatal("filter not ready")
+	}
 	return filter
 }

--- a/filter/filter_medium_test.go
+++ b/filter/filter_medium_test.go
@@ -29,8 +29,8 @@ import (
 	"github.com/jumptrading/influx-spout/spouttest"
 )
 
-const natsPort = 44446
-const probePort = 44447
+const natsPort = 44100
+const probePort = 44101
 
 func testConfig() *config.Config {
 	return &config.Config{

--- a/filter/filter_medium_test.go
+++ b/filter/filter_medium_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 const natsPort = 44446
+const probePort = 44447
 
 func testConfig() *config.Config {
 	return &config.Config{
@@ -46,6 +47,7 @@ func testConfig() *config.Config {
 			Match:   "hello",
 			Subject: "hello-subject",
 		}},
+		ProbePort: probePort,
 	}
 }
 
@@ -55,8 +57,7 @@ func TestFilterWorker(t *testing.T) {
 
 	conf := testConfig()
 
-	filter, err := StartFilter(conf)
-	require.NoError(t, err)
+	filter := startFilter(t, conf)
 	defer filter.Stop()
 
 	nc, err := nats.Connect(conf.NATSAddress)
@@ -123,8 +124,7 @@ func TestInvalidTimeStamps(t *testing.T) {
 	conf := testConfig()
 	conf.MaxTimeDeltaSecs = 10
 
-	filter, err := StartFilter(conf)
-	require.NoError(t, err)
+	filter := startFilter(t, conf)
 	defer filter.Stop()
 
 	nc, err := nats.Connect(conf.NATSAddress)
@@ -173,4 +173,11 @@ func TestInvalidTimeStamps(t *testing.T) {
 		`nats_dropped{component="filter",name="particle"} 0`,
 		`triggered{component="filter",name="particle",rule="hello-subject"} 2`,
 	})
+}
+
+func startFilter(t *testing.T, conf *config.Config) *Filter {
+	filter, err := StartFilter(conf)
+	require.NoError(t, err)
+	spouttest.AssertReadyProbe(t, conf.ProbePort)
+	return filter
 }

--- a/listener/listener_medium_test.go
+++ b/listener/listener_medium_test.go
@@ -231,7 +231,11 @@ func BenchmarkListenerLatency(b *testing.B) {
 func startListener(t require.TestingT, conf *config.Config) *Listener {
 	listener, err := StartListener(conf)
 	require.NoError(t, err)
-	spouttest.AssertReadyProbe(t, conf.ProbePort)
+	if !spouttest.CheckReadyProbe(conf.ProbePort) {
+		listener.Stop()
+		t.Errorf("listener not ready")
+		t.FailNow()
+	}
 	return listener
 }
 

--- a/listener/listener_medium_test.go
+++ b/listener/listener_medium_test.go
@@ -35,9 +35,9 @@ import (
 )
 
 const (
-	natsPort           = 44444
-	listenPort         = 44445
-	probePort          = 44446
+	natsPort           = 44000
+	listenPort         = 44001
+	probePort          = 44002
 	natsSubject        = "listener-test"
 	natsMonitorSubject = natsSubject + "-monitor"
 )

--- a/monitor/monitor_medium_test.go
+++ b/monitor/monitor_medium_test.go
@@ -34,6 +34,7 @@ import (
 
 const natsPort = 44447
 const httpPort = 44448
+const probePort = 44449
 
 var natsAddress = fmt.Sprintf("nats://127.0.0.1:%d", natsPort)
 
@@ -43,6 +44,7 @@ func testConfig() *config.Config {
 		NATSAddress:        natsAddress,
 		NATSSubjectMonitor: "monitor-test-monitor",
 		Port:               httpPort,
+		ProbePort:          probePort,
 	}
 }
 
@@ -55,12 +57,7 @@ func TestMonitor(t *testing.T) {
 	mon, err := monitor.Start(conf)
 	require.NoError(t, err)
 	defer mon.Stop()
-
-	select {
-	case <-mon.Ready():
-	case <-time.After(spouttest.LongWait):
-		t.Fatal("timed out waiting for monitor to be ready")
-	}
+	spouttest.AssertReadyProbe(t, conf.ProbePort)
 
 	publish := func(data []byte) {
 		err := nc.Publish(conf.NATSSubjectMonitor, data)

--- a/monitor/monitor_medium_test.go
+++ b/monitor/monitor_medium_test.go
@@ -32,9 +32,9 @@ import (
 	"github.com/jumptrading/influx-spout/spouttest"
 )
 
-const natsPort = 44447
-const httpPort = 44448
-const probePort = 44449
+const natsPort = 44300
+const httpPort = 44301
+const probePort = 44302
 
 var natsAddress = fmt.Sprintf("nats://127.0.0.1:%d", natsPort)
 

--- a/probes/probes.go
+++ b/probes/probes.go
@@ -1,0 +1,92 @@
+// Copyright 2018 Jump Trading
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package probes defines a simpler HTTP listener for Kubernetes style
+// liveness and readiness probes.
+package probes
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
+)
+
+// Listen starts a simple HTTP listener for responding to Kubernetes
+// liveness and readiness probes on the port specified. The returned
+// Probes instance has methods for setting the liveness and readiness
+// states.
+//
+// Liveness probes are served at /healthz.
+// Readiness probes are served at /readyz.
+func Listen(port int) *Probes {
+	p := &Probes{
+		alive: new(atomic.Value),
+		ready: new(atomic.Value),
+		server: &http.Server{
+			Addr: fmt.Sprintf(":%d", port),
+		},
+	}
+	p.alive.Store(true)
+	p.ready.Store(false)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", newHandler(p.alive))
+	mux.HandleFunc("/readyz", newHandler(p.ready))
+	p.server.Handler = mux
+
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		p.server.ListenAndServe()
+	}()
+
+	return p
+}
+
+// Probes contains a simple HTTP listener for serving Kubernetes
+// liveness and readiness probes.
+type Probes struct {
+	alive  *atomic.Value
+	ready  *atomic.Value
+	server *http.Server
+	wg     sync.WaitGroup
+}
+
+// SetAlive set the liveness state - true means alive/healthy.
+func (p *Probes) SetAlive(alive bool) {
+	p.alive.Store(alive)
+}
+
+// SetReady set the readiness state - true means ready.
+func (p *Probes) SetReady(ready bool) {
+	p.ready.Store(ready)
+}
+
+// Close shuts down the probes listener. It blocks until the listener
+// has stopped.
+func (p *Probes) Close() {
+	p.server.Close()
+	p.wg.Wait()
+}
+
+func newHandler(value *atomic.Value) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		if value.Load().(bool) {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.Error(w, http.StatusText(http.StatusServiceUnavailable), http.StatusServiceUnavailable)
+	}
+}

--- a/probes/probes_medium_test.go
+++ b/probes/probes_medium_test.go
@@ -14,7 +14,7 @@
 
 // +build medium
 
-package probes_test
+package probes
 
 import (
 	"fmt"
@@ -23,14 +23,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/jumptrading/influx-spout/probes"
 )
 
 const probesPort = 44450
 
 func TestProbes(t *testing.T) {
-	p := probes.Listen(probesPort)
+	p := Listen(probesPort)
 	defer p.Close()
 
 	// Starting state is alive but not ready.
@@ -48,6 +46,17 @@ func TestProbes(t *testing.T) {
 	assertReady(t)
 	p.SetReady(false)
 	assertNotReady(t)
+}
+
+func TestDisabled(t *testing.T) {
+	p := Listen(0)
+	defer p.Close()
+
+	assert.IsType(t, new(nullListener), p)
+
+	// Exercise methods (won't do anything).
+	p.SetAlive(false)
+	p.SetReady(false)
 }
 
 func assertAlive(t *testing.T) {

--- a/probes/probes_medium_test.go
+++ b/probes/probes_medium_test.go
@@ -1,0 +1,74 @@
+// Copyright 2018 Jump Trading
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build medium
+
+package probes_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jumptrading/influx-spout/probes"
+)
+
+const probesPort = 44450
+
+func TestProbes(t *testing.T) {
+	p := probes.Listen(probesPort)
+	defer p.Close()
+
+	// Starting state is alive but not ready.
+	assertAlive(t)
+	assertNotReady(t)
+
+	// Toggle alive.
+	p.SetAlive(false)
+	assertNotAlive(t)
+	p.SetAlive(true)
+	assertAlive(t)
+
+	// Toggle ready.
+	p.SetReady(true)
+	assertReady(t)
+	p.SetReady(false)
+	assertNotReady(t)
+}
+
+func assertAlive(t *testing.T) {
+	assertProbe(t, "healthz", http.StatusOK)
+}
+
+func assertNotAlive(t *testing.T) {
+	assertProbe(t, "healthz", http.StatusServiceUnavailable)
+}
+
+func assertReady(t *testing.T) {
+	assertProbe(t, "readyz", http.StatusOK)
+}
+
+func assertNotReady(t *testing.T) {
+	assertProbe(t, "readyz", http.StatusServiceUnavailable)
+}
+
+func assertProbe(t *testing.T, path string, expectedStatus int) {
+	url := fmt.Sprintf("http://localhost:%d/%s", probesPort, path)
+	resp, err := http.Get(url)
+	require.NoError(t, err)
+	assert.Equal(t, expectedStatus, resp.StatusCode)
+}

--- a/spouttest/e2e_test.go
+++ b/spouttest/e2e_test.go
@@ -38,21 +38,21 @@ import (
 )
 
 const (
-	natsPort    = 44500
-	influxdPort = 44501
+	natsPort    = 44600
+	influxdPort = 44601
 
-	listenerPort      = 44502
-	listenerProbePort = 55502
+	listenerPort      = 44610
+	listenerProbePort = 44611
 
-	httpListenerPort      = 44503
-	httpListenerProbePort = 55503
+	httpListenerPort      = 44620
+	httpListenerProbePort = 44621
 
-	filterProbePort = 55504
+	filterProbePort = 44631
 
-	writerProbePort = 55505
+	writerProbePort = 44641
 
-	monitorPort      = 44506
-	monitorProbePort = 55506
+	monitorPort      = 44650
+	monitorProbePort = 44651
 
 	influxDBName = "test"
 	sendCount    = 10
@@ -143,20 +143,20 @@ func TestEndToEnd(t *testing.T) {
 	expectedMetrics := regexp.MustCompile(`
 failed_nats_publish{component="filter",name="filter"} 0
 failed_nats_publish{component="listener",name="listener"} 0
-failed_writes{component="writer",influxdb_address="localhost",influxdb_dbname="test",influxdb_port="44501",name="writer"} 0
+failed_writes{component="writer",influxdb_address="localhost",influxdb_dbname="test",influxdb_port="44601",name="writer"} 0
 invalid_time{component="filter",name="filter"} 0
-max_pending{component="writer",influxdb_address="localhost",influxdb_dbname="test",influxdb_port="44501",name="writer"} \d+
+max_pending{component="writer",influxdb_address="localhost",influxdb_dbname="test",influxdb_port="44601",name="writer"} \d+
 nats_dropped{component="filter",name="filter"} 0
-nats_dropped{component="writer",influxdb_address="localhost",influxdb_dbname="test",influxdb_port="44501",name="writer",subject="system"} 0
+nats_dropped{component="writer",influxdb_address="localhost",influxdb_dbname="test",influxdb_port="44601",name="writer",subject="system"} 0
 passed{component="filter",name="filter"} 10
 processed{component="filter",name="filter"} 20
 read_errors{component="listener",name="listener"} 0
 received{component="listener",name="listener"} 5
-received{component="writer",influxdb_address="localhost",influxdb_dbname="test",influxdb_port="44501",name="writer"} 2
+received{component="writer",influxdb_address="localhost",influxdb_dbname="test",influxdb_port="44601",name="writer"} 2
 rejected{component="filter",name="filter"} 10
 sent{component="listener",name="listener"} 1
 triggered{component="filter",name="filter",rule="system"} 10
-write_requests{component="writer",influxdb_address="localhost",influxdb_dbname="test",influxdb_port="44501",name="writer"} 2
+write_requests{component="writer",influxdb_address="localhost",influxdb_dbname="test",influxdb_port="44601",name="writer"} 2
 $`[1:])
 	var lines string
 	for try := 0; try < 20; try++ {

--- a/writer/writer_medium_test.go
+++ b/writer/writer_medium_test.go
@@ -33,9 +33,9 @@ import (
 	"github.com/jumptrading/influx-spout/spouttest"
 )
 
-const natsPort = 44443
-const influxPort = 44445
-const probePort = 44446
+const natsPort = 44200
+const influxPort = 44201
+const probePort = 44202
 
 var natsAddress = fmt.Sprintf("nats://127.0.0.1:%d", natsPort)
 

--- a/writer/writer_medium_test.go
+++ b/writer/writer_medium_test.go
@@ -33,8 +33,9 @@ import (
 	"github.com/jumptrading/influx-spout/spouttest"
 )
 
-const influxPort = 44445
 const natsPort = 44443
+const influxPort = 44445
+const probePort = 44446
 
 var natsAddress = fmt.Sprintf("nats://127.0.0.1:%d", natsPort)
 
@@ -54,6 +55,7 @@ func testConfig() *config.Config {
 		Port:               influxPort,
 		Workers:            96,
 		NATSPendingMaxMB:   32,
+		ProbePort:          probePort,
 	}
 }
 
@@ -302,6 +304,11 @@ func runGnatsd(t FatalTestingT) (*nats.Conn, func()) {
 func startWriter(t require.TestingT, conf *config.Config) *Writer {
 	w, err := StartWriter(conf)
 	require.NoError(t, err)
+	if !spouttest.CheckReadyProbe(conf.ProbePort) {
+		w.Stop()
+		t.Errorf("writer not ready")
+		t.FailNow()
+	}
 	return w
 }
 


### PR DESCRIPTION
The listener, filter, writer and monitor components now all expose Kubernetes compatible `/healthz` and `/readyz` HTTP endpoints (if `probe_port` is set in configuration). See https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/.

All tests now use the endpoints to synchronise component startup. The "Ready" channels that were exposed by some components have been removed.

Closes #53.