### PR TITLE
listener: Changed succesful HTTP response code from 200 to 204

### DIFF
--- a/listener/listener.go
+++ b/listener/listener.go
@@ -220,6 +220,7 @@ func (l *Listener) setupHTTP() *http.Server {
 			l.processRead()
 			l.mu.Unlock()
 		}
+		w.WriteHeader(http.StatusNoContent)
 	})
 	return &http.Server{
 		Addr:    fmt.Sprintf(":%d", l.c.Port),


### PR DESCRIPTION
Telegraf HTTP InfluxDB output throws an error if Spout HTTP listener returns a 200 instead of 204 (StatusNoContent). The latter is the standard "OK" response from InfluxDB. 

```
 E! InfluxDB Output Error: Response Error: Status Code [200], expected [204], [<nil>]
```