### PR TITLE
Add support for HTTP "precision" parameter

### DIFF
--- a/filter/timestamp_small_test.go
+++ b/filter/timestamp_small_test.go
@@ -37,21 +37,9 @@ func TestExtractTimestamp(t *testing.T) {
 	}
 
 	check("", defaultTs)
-	check(" ", defaultTs)
-	check("weather temp=99", defaultTs)
 	check("weather,city=paris temp=60", defaultTs)
-	check("weather,city=paris temp=99,humidity=100", defaultTs)
 	check("weather temp=99 "+tsStr, ts)
 	check("weather temp=99 "+tsStr+"\n", ts)
-	check("weather,city=paris temp=60 "+tsStr, ts)
 	check("weather,city=paris temp=60,humidity=100 "+tsStr, ts)
 	check("weather,city=paris temp=60,humidity=100 "+tsStr+"\n", ts)
-
-	// Various invalid timestamps
-	check("weather temp=99 "+tsStr+" ", defaultTs)
-	check("weather temp=99 xxxxxxxxxxxxxxxxxxx", defaultTs)
-	check("weather temp=99 152076148x803180202", defaultTs)  // non-digit embedded
-	check("weather temp=99 11520761485803180202", defaultTs) // too long
-	check("weather temp=99 -"+tsStr, defaultTs)
-	check(tsStr, defaultTs)
 }

--- a/filter/worker.go
+++ b/filter/worker.go
@@ -160,7 +160,7 @@ func extractTimestamp(line []byte, defaultTs int64) int64 {
 		return defaultTs
 	}
 
-	out, _ := influx.ExtractTimestamp(line)
+	out, _ := influx.ExtractNanos(line)
 	if out == -1 {
 		return defaultTs
 	}

--- a/influx/timestamps.go
+++ b/influx/timestamps.go
@@ -126,15 +126,15 @@ func ExtractNanos(line []byte) (int64, int) {
 
 // SafeCalcTime safely calculates the time given. Will return error if
 // the time is outside the supported range.
-func SafeCalcTime(timestamp int64, precision string) (time.Time, error) {
+func SafeCalcTime(timestamp int64, precision string) (int64, error) {
 	mult := getPrecisionMultiplier(precision)
 	if t, ok := safeSignedMult(timestamp, mult); ok {
 		if t < minNanoTime || t > maxNanoTime {
-			return time.Time{}, ErrTimeOutOfRange
+			return 0, ErrTimeOutOfRange
 		}
-		return time.Unix(0, t).UTC(), nil
+		return t, nil
 	}
-	return time.Time{}, ErrTimeOutOfRange
+	return 0, ErrTimeOutOfRange
 }
 
 // getPrecisionMultiplier will return a multiplier for the precision specified.

--- a/influx/timestamps.go
+++ b/influx/timestamps.go
@@ -1,0 +1,58 @@
+// Copyright 2018 Jump Trading
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package influx
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/jumptrading/influx-spout/convert"
+)
+
+// maxTsLen is maximum number of characters a valid timestamp can be.
+var maxTsLen = len(fmt.Sprint(int64(math.MaxInt64)))
+
+// ExtractTimestamp returns the value and offset of the timestamp in a
+// InfluxDB line protocol line. If no valid timestamp is present, an
+// offset of -1 is returned.
+func ExtractTimestamp(line []byte) (int64, int) {
+	length := len(line)
+
+	if length < 6 {
+		return -1, -1
+	}
+
+	// Remove trailing newline, if present.
+	if line[length-1] == '\n' {
+		length--
+		line = line[:length]
+	}
+
+	// Expect a space just before the timestamp.
+	from := length - maxTsLen - 1
+	if from < 0 {
+		from = 0
+	}
+	for i := from; i < length; i++ {
+		if line[i] == ' ' {
+			out, err := convert.ToInt(line[i+1:])
+			if err != nil {
+				return -1, -1
+			}
+			return out, i + 1
+		}
+	}
+	return -1, -1
+}

--- a/influx/timestamps.go
+++ b/influx/timestamps.go
@@ -12,17 +12,50 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Parts of this package are adapted from the InfluxDB code base
+// (https://github.com/influxdata/influxdb).
+
 package influx
 
 import (
 	"fmt"
 	"math"
+	"time"
 
 	"github.com/jumptrading/influx-spout/convert"
 )
 
-// maxTsLen is maximum number of characters a valid timestamp can be.
-var maxTsLen = len(fmt.Sprint(int64(math.MaxInt64)))
+const (
+	// minNanoTime is the minumum time that can be represented.
+	//
+	// 1677-09-21 00:12:43.145224194 +0000 UTC
+	//
+	// The two lowest minimum integers are used as sentinel values.  The
+	// minimum value needs to be used as a value lower than any other value for
+	// comparisons and another separate value is needed to act as a sentinel
+	// default value that is unusable by the user, but usable internally.
+	// Because these two values need to be used for a special purpose, we do
+	// not allow users to write points at these two times.
+	minNanoTime = int64(math.MinInt64) + 2
+
+	// maxNanoTime is the maximum time that can be represented.
+	//
+	// 2262-04-11 23:47:16.854775806 +0000 UTC
+	//
+	// The highest time represented by a nanosecond needs to be used for an
+	// exclusive range in the shard group, so the maximum time needs to be one
+	// less than the possible maximum number of nanoseconds representable by an
+	// int64 so that we don't lose a point at that one time.
+	maxNanoTime = int64(math.MaxInt64) - 1
+)
+
+var (
+	// maxTsLen is maximum number of characters a valid timestamp can be.
+	maxTsLen = len(fmt.Sprint(maxNanoTime))
+
+	// ErrTimeOutOfRange gets returned when time is out of the representable range using int64 nanoseconds since the epoch.
+	ErrTimeOutOfRange = fmt.Errorf("time outside range %d - %d", minNanoTime, maxNanoTime)
+)
 
 // ExtractTimestamp returns the value and offset of the timestamp in a
 // InfluxDB line protocol line. If no valid timestamp is present, an
@@ -55,4 +88,47 @@ func ExtractTimestamp(line []byte) (int64, int) {
 		}
 	}
 	return -1, -1
+}
+
+// SafeCalcTime safely calculates the time given. Will return error if
+// the time is outside the supported range.
+func SafeCalcTime(timestamp int64, precision string) (time.Time, error) {
+	mult := getPrecisionMultiplier(precision)
+	if t, ok := safeSignedMult(timestamp, mult); ok {
+		if t < minNanoTime || t > maxNanoTime {
+			return time.Time{}, ErrTimeOutOfRange
+		}
+		return time.Unix(0, t).UTC(), nil
+	}
+	return time.Time{}, ErrTimeOutOfRange
+}
+
+// getPrecisionMultiplier will return a multiplier for the precision specified.
+func getPrecisionMultiplier(precision string) int64 {
+	d := time.Nanosecond
+	switch precision {
+	case "u":
+		d = time.Microsecond
+	case "ms":
+		d = time.Millisecond
+	case "s":
+		d = time.Second
+	case "m":
+		d = time.Minute
+	case "h":
+		d = time.Hour
+	}
+	return int64(d)
+}
+
+// Perform the multiplication and check to make sure it didn't overflow.
+func safeSignedMult(a, b int64) (int64, bool) {
+	if a == 0 || b == 0 || a == 1 || b == 1 {
+		return a * b, true
+	}
+	if a == minNanoTime || b == maxNanoTime {
+		return 0, false
+	}
+	c := a * b
+	return c, c/b == a
 }

--- a/influx/timestamps_small_test.go
+++ b/influx/timestamps_small_test.go
@@ -1,0 +1,62 @@
+// Copyright 2018 Jump Trading
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build small
+
+package influx_test
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/jumptrading/influx-spout/influx"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractTimestamp(t *testing.T) {
+	ts := time.Date(1997, 6, 5, 4, 3, 2, 1, time.UTC).UnixNano()
+	tsStr := strconv.FormatInt(ts, 10)
+
+	check := func(input string, expectedTs int64, expectedOffset int) {
+		ts, offset := influx.ExtractTimestamp([]byte(input))
+		assert.Equal(t, expectedTs, ts, "ExtractTimestamp(%q)", input)
+		assert.Equal(t, expectedOffset, offset, "ExtractTimestamp(%q)", input)
+	}
+
+	noTimestamp := func(input string) {
+		ts, offset := influx.ExtractTimestamp([]byte(input))
+		assert.Equal(t, -1, offset, "ExtractTimestamp(%q)", input)
+		assert.Equal(t, int64(-1), ts, "ExtractTimestamp(%q)", input)
+	}
+
+	noTimestamp("")
+	noTimestamp(" ")
+	noTimestamp("weather temp=99")
+	noTimestamp("weather,city=paris temp=60")
+	noTimestamp("weather,city=paris temp=99,humidity=100")
+	check("weather temp=99 "+tsStr, ts, 16)
+	check("weather temp=99 "+tsStr+"\n", ts, 16)
+	check("weather,city=paris temp=60 "+tsStr, ts, 27)
+	check("weather,city=paris temp=60,humidity=100 "+tsStr, ts, 40)
+	check("weather,city=paris temp=60,humidity=100 "+tsStr+"\n", ts, 40)
+
+	// Various invalid timestamps
+	noTimestamp("weather temp=99 " + tsStr + " ")       // trailing whitespace
+	noTimestamp("weather temp=99 xxxxxxxxxxxxxxxxxxx")  // not digits
+	noTimestamp("weather temp=99 152076148x803180202")  // embedded non-digit
+	noTimestamp("weather temp=99 11520761485803180202") // too long
+	noTimestamp("weather temp=99 -" + tsStr)            // negative
+	noTimestamp(tsStr)                                  // timestamp only
+}

--- a/influx/timestamps_small_test.go
+++ b/influx/timestamps_small_test.go
@@ -103,56 +103,56 @@ func TestSafeCalcTime(t *testing.T) {
 		name      string
 		ts        int64
 		precision string
-		exp       time.Time
+		exp       int64
 	}{
 		{
 			name:      "nanosecond by default",
 			ts:        946730096789012345,
 			precision: "",
-			exp:       time.Unix(0, 946730096789012345),
+			exp:       946730096789012345,
 		},
 		{
 			name:      "nanosecond",
 			ts:        946730096789012345,
 			precision: "n",
-			exp:       time.Unix(0, 946730096789012345),
+			exp:       946730096789012345,
 		},
 		{
 			name:      "microsecond",
 			ts:        946730096789012,
 			precision: "u",
-			exp:       time.Unix(0, 946730096789012000),
+			exp:       946730096789012000,
 		},
 		{
 			name:      "millisecond",
 			ts:        946730096789,
 			precision: "ms",
-			exp:       time.Unix(0, 946730096789000000),
+			exp:       946730096789000000,
 		},
 		{
 			name:      "second",
 			ts:        946730096,
 			precision: "s",
-			exp:       time.Unix(0, 946730096000000000),
+			exp:       946730096000000000,
 		},
 		{
 			name:      "minute",
 			ts:        15778834,
 			precision: "m",
-			exp:       time.Unix(0, 946730040000000000),
+			exp:       946730040000000000,
 		},
 		{
 			name:      "hour",
 			ts:        262980,
 			precision: "h",
-			exp:       time.Unix(0, 946728000000000000),
+			exp:       946728000000000000,
 		},
 	}
 
 	for _, test := range tests {
 		ts, err := influx.SafeCalcTime(test.ts, test.precision)
 		assert.NoError(t, err, `%s: SafeCalcTime() failed. got %s`, test.name, err)
-		assert.True(t, ts.Equal(test.exp), "%s: expected %s, got %s", test.name, test.exp, ts)
+		assert.Equal(t, test.exp, ts, "%s: expected %s, got %s", test.name, test.exp, ts)
 	}
 }
 

--- a/listener/batch.go
+++ b/listener/batch.go
@@ -71,6 +71,19 @@ func (b *batch) readFrom(r io.Reader) (int, error) {
 	}
 }
 
+// appendBytes adds some bytes to the batch, growing the batch if
+// required.
+func (b *batch) appendBytes(more []byte) {
+	lenMore := len(more)
+	for b.remaining() < lenMore {
+		b.grow()
+	}
+
+	lenBatch := len(b.buf)
+	b.buf = b.buf[:lenBatch+lenMore]
+	copy(b.buf[lenBatch:], more)
+}
+
 // size returns the number of bytes currently stored in the batch.
 func (b *batch) size() int {
 	return len(b.buf)

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -307,7 +307,7 @@ func applyTimestampPrecision(line []byte, precision string) []byte {
 
 	newLine := make([]byte, offset, offset+influx.MaxTsLen+1)
 	copy(newLine, line[:offset])
-	newLine = strconv.AppendInt(newLine, newTs.UnixNano(), 10)
+	newLine = strconv.AppendInt(newLine, newTs, 10)
 	return append(newLine, '\n')
 }
 

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -17,19 +17,22 @@
 package listener
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
 	"log"
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"sync"
 	"time"
 
-	"github.com/nats-io/go-nats"
-
 	"github.com/jumptrading/influx-spout/config"
+	"github.com/jumptrading/influx-spout/influx"
 	"github.com/jumptrading/influx-spout/probes"
 	"github.com/jumptrading/influx-spout/stats"
+	nats "github.com/nats-io/go-nats"
 )
 
 const (
@@ -205,27 +208,107 @@ func (l *Listener) listenUDP(sc *net.UDPConn) {
 
 func (l *Listener) setupHTTP() *http.Server {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/write", func(w http.ResponseWriter, r *http.Request) {
-		l.mu.Lock()
-		bytesRead, err := l.batch.readFrom(r.Body)
-		l.mu.Unlock()
-		if err != nil {
-			l.stats.Inc(statReadErrors)
-		}
-		if bytesRead > 0 {
-			if l.c.Debug {
-				log.Printf("HTTP listener read %d bytes", bytesRead)
-			}
-			l.mu.Lock()
-			l.processRead()
-			l.mu.Unlock()
-		}
-		w.WriteHeader(http.StatusNoContent)
-	})
+	mux.HandleFunc("/write", l.handleHTTPWrite)
 	return &http.Server{
 		Addr:    fmt.Sprintf(":%d", l.c.Port),
 		Handler: mux,
 	}
+}
+
+func (l *Listener) handleHTTPWrite(w http.ResponseWriter, r *http.Request) {
+	bytesRead, err := l.readHTTPBody(r)
+	if bytesRead > 0 {
+		if l.c.Debug {
+			log.Printf("HTTP listener read %d bytes", bytesRead)
+		}
+		l.mu.Lock()
+		l.processRead()
+		l.mu.Unlock()
+	}
+	if err != nil {
+		l.stats.Inc(statReadErrors)
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (l *Listener) readHTTPBody(r *http.Request) (int, error) {
+	precision := r.URL.Query().Get("precision")
+
+	if precision == "" || precision == "ns" {
+		// Fast-path when timestamps are already in nanoseconds - no
+		// need for conversion.
+		return l.readHTTPBodyNanos(r)
+	}
+
+	// Non-nanosecond precison specified. Read lines individually and
+	// convert timestamps to nanoseconds.
+	return l.readHTTPBodyWithPrecision(r, precision)
+}
+
+func (l *Listener) readHTTPBodyNanos(r *http.Request) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.batch.readFrom(r.Body)
+}
+
+func (l *Listener) readHTTPBodyWithPrecision(r *http.Request, precision string) (int, error) {
+	scanner := bufio.NewScanner(r.Body)
+
+	// scanLines is like bufio.ScanLines but the returned lines
+	// includes the trailing newlines. Leaving the newline on the line
+	// is useful for incoming lines that don't contain a timestamp and
+	// therefore should pass through unchanged.
+	scanner.Split(scanLines)
+
+	bytesRead := 0
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		bytesRead += len(line)
+		if len(line) <= 1 {
+			continue
+		}
+
+		newLine := applyTimestampPrecision(line, precision)
+		l.mu.Lock()
+		l.batch.appendBytes(newLine)
+		l.mu.Unlock()
+	}
+	return bytesRead, scanner.Err()
+}
+
+func scanLines(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+	if i := bytes.IndexByte(data, '\n'); i >= 0 {
+		// We have a full newline-terminated line.
+		return i + 1, data[0 : i+1], nil
+
+	}
+	// If we're at EOF, we have a final, non-terminated line. Return it.
+	if atEOF {
+		return len(data), data, nil
+
+	}
+	// Request more data.
+	return 0, nil, nil
+}
+
+func applyTimestampPrecision(line []byte, precision string) []byte {
+	ts, offset := influx.ExtractTimestamp(line)
+	if offset == -1 {
+		return line
+	}
+
+	newTs, err := influx.SafeCalcTime(ts, precision)
+	if err != nil {
+		return line
+	}
+
+	newLine := make([]byte, offset, offset+influx.MaxTsLen+1)
+	copy(newLine, line[:offset])
+	newLine = strconv.AppendInt(newLine, newTs.UnixNano(), 10)
+	return append(newLine, '\n')
 }
 
 func (l *Listener) listenHTTP(server *http.Server) {


### PR DESCRIPTION
The HTTP listener component now supports an optional `precision` argument which specifies the precision of the timestamps being sent. This mimics a similar feature of InfluxDB itself. Care has been taken to minimise the performance impact of this change and a fast path is used if nanosecond precision is in use.

To support this change there's been some cleanup of influx-spout's timestamp handling functionality. Benchmarks for the HTTP listener have also been added to guard against future regressions.

Closes #72.