### PR TITLE
Disable benchmark logs

### DIFF
--- a/filter/rules_small_test.go
+++ b/filter/rules_small_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jumptrading/influx-spout/spouttest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -153,6 +154,9 @@ func TestMeasurementName(t *testing.T) {
 var result int
 
 func BenchmarkLineLookup(b *testing.B) {
+	spouttest.SuppressLogs()
+	defer spouttest.RestoreLogs()
+
 	rs := new(RuleSet)
 	rs.Append(CreateBasicRule("hello", ""))
 	line := []byte("hello world=42")
@@ -164,6 +168,9 @@ func BenchmarkLineLookup(b *testing.B) {
 }
 
 func BenchmarkLineLookupRegex(b *testing.B) {
+	spouttest.SuppressLogs()
+	defer spouttest.RestoreLogs()
+
 	rs := new(RuleSet)
 	rs.Append(CreateRegexRule("hello|abcde", ""))
 	line := []byte("hello world=42")
@@ -175,6 +182,9 @@ func BenchmarkLineLookupRegex(b *testing.B) {
 }
 
 func BenchmarkLineLookupNegativeRegex(b *testing.B) {
+	spouttest.SuppressLogs()
+	defer spouttest.RestoreLogs()
+
 	rs := new(RuleSet)
 	rs.Append(CreateNegativeRegexRule("hello|abcde", ""))
 	line := []byte("hello world=42")
@@ -186,6 +196,9 @@ func BenchmarkLineLookupNegativeRegex(b *testing.B) {
 }
 
 func BenchmarkProcessBatch(b *testing.B) {
+	spouttest.SuppressLogs()
+	defer spouttest.RestoreLogs()
+
 	// Run the Filter worker with a fake NATS connection.
 	rs := new(RuleSet)
 	rs.Append(CreateBasicRule("hello", "hello-out"))

--- a/listener/listener_medium_test.go
+++ b/listener/listener_medium_test.go
@@ -300,6 +300,12 @@ func TestHTTPListenerConcurrency(t *testing.T) {
 }
 
 func BenchmarkListenerLatency(b *testing.B) {
+	spouttest.SuppressLogs()
+	defer spouttest.RestoreLogs()
+
+	s := spouttest.RunGnatsd(natsPort)
+	defer s.Shutdown()
+
 	listener := startListener(b, testConfig())
 	defer listener.Stop()
 

--- a/listener/listener_medium_test.go
+++ b/listener/listener_medium_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -61,16 +60,6 @@ func init() {
 	statsInterval = 500 * time.Millisecond
 }
 
-func TestMain(m *testing.M) {
-	os.Exit(runMain(m))
-}
-
-func runMain(m *testing.M) int {
-	s := spouttest.RunGnatsd(natsPort)
-	defer s.Shutdown()
-	return m.Run()
-}
-
 func testConfig() *config.Config {
 	return &config.Config{
 		Mode:               "listener",
@@ -87,6 +76,9 @@ func testConfig() *config.Config {
 }
 
 func TestBatching(t *testing.T) {
+	s := spouttest.RunGnatsd(natsPort)
+	defer s.Shutdown()
+
 	conf := testConfig()
 	conf.BatchMessages = numLines // batch messages into one packet
 
@@ -115,6 +107,9 @@ func TestBatching(t *testing.T) {
 }
 
 func TestWhatComesAroundGoesAround(t *testing.T) {
+	s := spouttest.RunGnatsd(natsPort)
+	defer s.Shutdown()
+
 	listener := startListener(t, testConfig())
 	defer listener.Stop()
 
@@ -141,6 +136,9 @@ func TestWhatComesAroundGoesAround(t *testing.T) {
 }
 
 func TestBatchBufferFull(t *testing.T) {
+	s := spouttest.RunGnatsd(natsPort)
+	defer s.Shutdown()
+
 	conf := testConfig()
 	// Set batch size high so that the batch will only send due to the
 	// batch buffer filling up.
@@ -183,6 +181,9 @@ loop:
 }
 
 func TestHTTPListener(t *testing.T) {
+	s := spouttest.RunGnatsd(natsPort)
+	defer s.Shutdown()
+
 	conf := testConfig()
 	listener, err := StartHTTPListener(conf)
 	require.NoError(t, err)
@@ -211,6 +212,9 @@ func TestHTTPListener(t *testing.T) {
 }
 
 func TestHTTPListenerBigPOST(t *testing.T) {
+	s := spouttest.RunGnatsd(natsPort)
+	defer s.Shutdown()
+
 	conf := testConfig()
 	conf.ListenerBatchBytes = 1024
 	// Use a batch size > 1. Even though a single write will be made,
@@ -244,6 +248,9 @@ func TestHTTPListenerBigPOST(t *testing.T) {
 }
 
 func TestHTTPListenerConcurrency(t *testing.T) {
+	s := spouttest.RunGnatsd(natsPort)
+	defer s.Shutdown()
+
 	conf := testConfig()
 	listener, err := StartHTTPListener(conf)
 	require.NoError(t, err)

--- a/perfcheck
+++ b/perfcheck
@@ -22,8 +22,7 @@ capture_benchmarks() {
     test_sizes=$1
     output=$2
 
-    packages=`go list ./... | grep -v vendor`
-    go test -tags="$test_sizes" -run='^$' -bench=. $packages &>> $output
+    go test -tags="$test_sizes" -run='^$' -bench=. ./... &>> $output
     if [[ $? -ne 0 ]]; then
         cat $output
         exit 1

--- a/spouttest/logs.go
+++ b/spouttest/logs.go
@@ -1,0 +1,17 @@
+package spouttest
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+// SuppressLogs causes log output globally to be discarded.
+func SuppressLogs() {
+	log.SetOutput(ioutil.Discard)
+}
+
+// RestoreLogs causes log output globally to be sent to stderr.
+func RestoreLogs() {
+	log.SetOutput(os.Stderr)
+}

--- a/writer/writer_medium_test.go
+++ b/writer/writer_medium_test.go
@@ -263,6 +263,9 @@ func TestNegativeRegexFilterRule(t *testing.T) {
 }
 
 func BenchmarkWriterLatency(b *testing.B) {
+	spouttest.SuppressLogs()
+	defer spouttest.RestoreLogs()
+
 	nc, closeNATS := runGnatsd(b)
 	defer closeNATS()
 


### PR DESCRIPTION
The logs are messing up the output meaning that perfcheck isn't able to compare some benchmarks.

Also:
* Removed the manual filtering of the `vendor` directory in perfcheck. Modern Go versions do this by default.
* Avoid unnecessary use of TestMain in listener tests. TestMain isn't really necessary, is a little confusing and it's best to isolate the gnatsd instance for each test for reliability reasons.

Once this lands, I'll merge the benchmark log suppression change into the `perfcheck-reference` branch so that all benchmarks are being compared again.