### PR TITLE
Improve stats performance

### DIFF
--- a/filter/filter.go
+++ b/filter/filter.go
@@ -18,15 +18,14 @@ package filter
 import (
 	"fmt"
 	"log"
-	"sort"
-	"strings"
 	"sync"
 	"time"
+
+	"github.com/nats-io/go-nats"
 
 	"github.com/jumptrading/influx-spout/config"
 	"github.com/jumptrading/influx-spout/probes"
 	"github.com/jumptrading/influx-spout/stats"
-	"github.com/nats-io/go-nats"
 )
 
 // Name for supported stats
@@ -60,7 +59,8 @@ func StartFilter(conf *config.Config) (_ *Filter, err error) {
 		return nil, err
 	}
 
-	stats := initStats(rules)
+	st := initStats()
+	ruleSt := stats.NewAnon(rules.Count())
 
 	f.nc, err = f.natsConnect()
 	if err != nil {
@@ -72,7 +72,8 @@ func StartFilter(conf *config.Config) (_ *Filter, err error) {
 		w, err := newWorker(
 			f.c.MaxTimeDeltaSecs,
 			rules,
-			stats,
+			st,
+			ruleSt,
 			f.c.Debug,
 			f.natsConnect,
 			f.c.NATSSubjectJunkyard,
@@ -102,7 +103,7 @@ func StartFilter(conf *config.Config) (_ *Filter, err error) {
 	}
 
 	f.wg.Add(1)
-	go f.startStatistician(stats, rules)
+	go f.startStatistician(st, ruleSt, rules)
 
 	log.Printf("filter subscribed to [%s] at %s with %d rules\n",
 		f.c.NATSSubject[0], f.c.NATSAddress, rules.Count())
@@ -117,22 +118,6 @@ func (f *Filter) natsConnect() (natsConn, error) {
 		return nil, fmt.Errorf("NATS: failed to connect: %v", err)
 	}
 	return nc, nil
-}
-
-func initStats(rules *RuleSet) *stats.Stats {
-	// Initialise
-	statNames := []string{
-		statPassed,
-		statProcessed,
-		statRejected,
-		statInvalidTime,
-		statFailedNATSPublish,
-		statNATSDropped,
-	}
-	for i := 0; i < rules.Count(); i++ {
-		statNames = append(statNames, ruleToStatsName(i))
-	}
-	return stats.New(statNames...)
 }
 
 // natsConn allows a mock nats.Conn to be substituted in during tests.
@@ -176,7 +161,7 @@ func (f *Filter) Stop() {
 // startStatistician defines a goroutine that is responsible for
 // regularly sending the filter's statistics to the monitoring
 // backend.
-func (f *Filter) startStatistician(st *stats.Stats, rules *RuleSet) {
+func (f *Filter) startStatistician(st *stats.Stats, ruleSt *stats.AnonStats, rules *RuleSet) {
 	defer f.wg.Done()
 
 	generalLabels := map[string]string{
@@ -188,7 +173,8 @@ func (f *Filter) startStatistician(st *stats.Stats, rules *RuleSet) {
 		f.updateNATSDropped(st)
 
 		now := time.Now()
-		snap, ruleCounts := splitSnapshot(st.Snapshot())
+		snap := st.Snapshot()
+		ruleCounts := ruleSt.Snapshot()
 
 		// publish the general stats
 		lines := stats.SnapshotToPrometheus(snap, now, generalLabels)
@@ -198,7 +184,7 @@ func (f *Filter) startStatistician(st *stats.Stats, rules *RuleSet) {
 		for i, subject := range rules.Subjects() {
 			f.nc.Publish(f.c.NATSSubjectMonitor, stats.CounterToPrometheus(
 				"triggered",
-				ruleCounts[i],
+				int(ruleCounts[i]),
 				now,
 				map[string]string{
 					"component": "filter",
@@ -225,38 +211,13 @@ func (f *Filter) updateNATSDropped(st *stats.Stats) {
 	st.Max(statNATSDropped, dropped)
 }
 
-const rulePrefix = "rule-"
-
-// ruleToStatsName converts a rule index to a name to a key for use
-// with a stats.Stats instance.
-func ruleToStatsName(i int) string {
-	return fmt.Sprintf("%s%06d", rulePrefix, i)
-}
-
-// splitSnapshot takes a Snapshot and splits out the rule counters
-// from the others. The rule counters are returned in an ordered slice
-// while the other counters are returned as a new (smaller) Snapshot.
-func splitSnapshot(snap stats.Snapshot) (stats.Snapshot, []int) {
-	var genSnap stats.Snapshot
-	var ruleSnap stats.Snapshot
-
-	// Split up rule counters from the others.
-	for _, counter := range snap {
-		if strings.HasPrefix(counter.Name, rulePrefix) {
-			ruleSnap = append(ruleSnap, counter)
-		} else {
-			genSnap = append(genSnap, counter)
-		}
-	}
-
-	// Sort the rule counters by name and extract just the counts.
-	sort.Slice(ruleSnap, func(i, j int) bool {
-		return ruleSnap[i].Name < ruleSnap[j].Name
-	})
-	ruleCounts := make([]int, len(ruleSnap))
-	for i, counter := range ruleSnap {
-		ruleCounts[i] = counter.Value
-	}
-
-	return genSnap, ruleCounts
+func initStats() *stats.Stats {
+	return stats.New(
+		statPassed,
+		statProcessed,
+		statRejected,
+		statInvalidTime,
+		statFailedNATSPublish,
+		statNATSDropped,
+	)
 }

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -208,7 +208,7 @@ func (f *Filter) updateNATSDropped(st *stats.Stats) {
 		log.Printf("NATS: failed to read subscription drops: %v", err)
 		return
 	}
-	st.Max(statNATSDropped, dropped)
+	st.Max(statNATSDropped, uint64(dropped))
 }
 
 func initStats() *stats.Stats {

--- a/filter/rules_small_test.go
+++ b/filter/rules_small_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/jumptrading/influx-spout/spouttest"
+	"github.com/jumptrading/influx-spout/stats"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -204,7 +205,15 @@ func BenchmarkProcessBatch(b *testing.B) {
 	rs.Append(CreateBasicRule("hello", "hello-out"))
 	rs.Append(CreateRegexRule("foo|bar", "foobar-out"))
 
-	w, err := newWorker(600, rs, initStats(rs), false, nullNATSConnect, "junk")
+	w, err := newWorker(
+		600,
+		rs,
+		initStats(),
+		stats.NewAnon(rs.Count()),
+		false,
+		nullNATSConnect,
+		"junk",
+	)
 	require.NoError(b, err)
 
 	lines := []string{

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -339,7 +339,7 @@ func (l *Listener) processRead() {
 	// growing the batch unnecessarily (allocations hurt performance).
 	batchNearlyFull := l.c.ListenerBatchBytes-l.batch.size() <= maxUDPDatagramSize
 
-	if statReceived%l.c.BatchMessages == 0 || batchNearlyFull {
+	if statReceived%uint64(l.c.BatchMessages) == 0 || batchNearlyFull {
 		l.stats.Inc(statSent)
 		if err := l.nc.Publish(l.c.NATSSubject[0], l.batch.bytes()); err != nil {
 			l.stats.Inc(statFailedNATSPublish)

--- a/stats/anonstats.go
+++ b/stats/anonstats.go
@@ -1,0 +1,69 @@
+// Copyright 2018 Jump Trading
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stats
+
+import (
+	"sync/atomic"
+)
+
+// NewAnon creates a new AnonStats instance of the given size.
+func NewAnon(size int) *AnonStats {
+	return &AnonStats{
+		counts: make([]uint64, size),
+	}
+}
+
+// AnonStats tracks a number of counters in a goroutine safe
+// way. Counters are addressed by integer index.
+type AnonStats struct {
+	counts []uint64
+}
+
+// Get retrieves the current value of a counter. It panics if the
+// counter is not valid.
+func (s *AnonStats) Get(i int) uint64 {
+	return atomic.LoadUint64(&s.counts[i])
+}
+
+// Inc increments a stats counter, returning the new value. It panics
+// if the counter is not valid.
+func (s *AnonStats) Inc(i int) uint64 {
+	return atomic.AddUint64(&s.counts[i], 1)
+}
+
+// Max updates a counter if the value supplied is greater than the
+// previous one. It panics if the counter is not valid.
+func (s *AnonStats) Max(i int, newVal uint64) uint64 {
+	pCount := &s.counts[i]
+	for {
+		curVal := atomic.LoadUint64(pCount)
+		if newVal <= curVal {
+			return curVal
+		}
+		if atomic.CompareAndSwapUint64(pCount, curVal, newVal) {
+			return newVal
+		}
+	}
+}
+
+// Snapshot returns the current values of all the counters.
+func (s *AnonStats) Snapshot() []uint64 {
+	numCounts := len(s.counts)
+	out := make([]uint64, numCounts)
+	for i := 0; i < numCounts; i++ {
+		out[i] = s.Get(i)
+	}
+	return out
+}

--- a/stats/anonstats_test.go
+++ b/stats/anonstats_test.go
@@ -1,0 +1,138 @@
+// Copyright 2018 Jump Trading
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build small
+
+package stats_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/jumptrading/influx-spout/stats"
+)
+
+func TestAnonBasics(t *testing.T) {
+	s := stats.NewAnon(2)
+
+	assert.Equal(t, uint64(0), s.Get(0))
+	assert.Equal(t, uint64(0), s.Get(1))
+
+	assert.Equal(t, uint64(1), s.Inc(0))
+	assert.Equal(t, uint64(1), s.Get(0))
+	assert.Equal(t, uint64(2), s.Inc(0))
+	assert.Equal(t, uint64(2), s.Get(0))
+	assert.Equal(t, uint64(3), s.Inc(0))
+	assert.Equal(t, uint64(4), s.Inc(0))
+	assert.Equal(t, uint64(4), s.Get(0))
+
+	assert.Equal(t, uint64(0), s.Get(1))
+}
+
+func TestAnonConcurrentAdd(t *testing.T) {
+	s := stats.NewAnon(1)
+
+	const goroutines = 100
+	const incs = 100
+	wg := new(sync.WaitGroup)
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			var last uint64
+			defer wg.Done()
+			for i := 0; i < incs; i++ {
+				current := s.Inc(0)
+				if current <= last {
+					panic("did not increment")
+				}
+				last = current
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, uint64(goroutines*incs), s.Get(0))
+}
+
+func TestAnonMax(t *testing.T) {
+	s := stats.NewAnon(1)
+
+	assert.Equal(t, uint64(0), s.Get(0))
+	assert.Equal(t, uint64(0), s.Max(0, 0))
+	assert.Equal(t, uint64(0), s.Get(0))
+
+	assert.Equal(t, uint64(4), s.Max(0, 4))
+	assert.Equal(t, uint64(4), s.Get(0))
+
+	assert.Equal(t, uint64(4), s.Max(0, 3))
+	assert.Equal(t, uint64(4), s.Get(0))
+
+	assert.Equal(t, uint64(5), s.Max(0, 5))
+	assert.Equal(t, uint64(5), s.Get(0))
+}
+
+func TestAnonConcurrentMax(t *testing.T) {
+	s := stats.NewAnon(1)
+
+	const goroutines = 100
+	const top = 100
+	wg := new(sync.WaitGroup)
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for i := uint64(1); i <= top; i++ {
+				if s.Max(0, uint64(i)) < i {
+					panic("max failed")
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, uint64(top), s.Get(0))
+}
+
+func TestAnonInvalid(t *testing.T) {
+	s := stats.NewAnon(1)
+
+	assert.Equal(t, uint64(0), s.Get(0))
+	assert.Panics(t, func() { s.Get(1) })
+	assert.Panics(t, func() { s.Inc(1) })
+	assert.Panics(t, func() { s.Max(1, 1) })
+	assert.Equal(t, uint64(0), s.Get(0))
+}
+
+func TestAnonSnapshot(t *testing.T) {
+	s := stats.NewAnon(3)
+	s.Inc(0)
+	s.Inc(1)
+	s.Inc(1)
+
+	assert.Equal(t, []uint64{1, 2, 0}, s.Snapshot())
+}
+
+func BenchmarkAnonStats(b *testing.B) {
+	s := stats.NewAnon(2)
+
+	for i := 0; i < b.N; i++ {
+		s.Inc(0)
+		_ = s.Get(0)
+
+		_ = s.Get(1)
+		s.Inc(1)
+	}
+}

--- a/stats/stats_small_test.go
+++ b/stats/stats_small_test.go
@@ -27,44 +27,45 @@ import (
 func TestBasics(t *testing.T) {
 	s := stats.New("foo", "bar")
 
-	assert.Equal(t, 0, s.Get("foo"))
-	assert.Equal(t, 0, s.Get("bar"))
+	assert.Equal(t, uint64(0), s.Get("foo"))
+	assert.Equal(t, uint64(0), s.Get("bar"))
 
-	assert.Equal(t, 1, s.Inc("foo"))
-	assert.Equal(t, 1, s.Get("foo"))
-	assert.Equal(t, 2, s.Inc("foo"))
-	assert.Equal(t, 2, s.Get("foo"))
-	assert.Equal(t, 3, s.Inc("foo"))
-	assert.Equal(t, 4, s.Inc("foo"))
-	assert.Equal(t, 4, s.Get("foo"))
+	assert.Equal(t, uint64(1), s.Inc("foo"))
+	assert.Equal(t, uint64(1), s.Get("foo"))
+	assert.Equal(t, uint64(2), s.Inc("foo"))
+	assert.Equal(t, uint64(2), s.Get("foo"))
+	assert.Equal(t, uint64(3), s.Inc("foo"))
+	assert.Equal(t, uint64(4), s.Inc("foo"))
+	assert.Equal(t, uint64(4), s.Get("foo"))
 
-	assert.Equal(t, 0, s.Get("bar"))
+	assert.Equal(t, uint64(0), s.Get("bar"))
 }
 
 func TestMax(t *testing.T) {
 	s := stats.New("foo")
 
-	assert.Equal(t, 0, s.Get("foo"))
-	assert.Equal(t, 0, s.Max("foo", 0))
-	assert.Equal(t, 0, s.Get("foo"))
+	assert.Equal(t, uint64(0), s.Get("foo"))
+	assert.Equal(t, uint64(0), s.Max("foo", 0))
+	assert.Equal(t, uint64(0), s.Get("foo"))
 
-	assert.Equal(t, 4, s.Max("foo", 4))
-	assert.Equal(t, 4, s.Get("foo"))
+	assert.Equal(t, uint64(4), s.Max("foo", 4))
+	assert.Equal(t, uint64(4), s.Get("foo"))
 
-	assert.Equal(t, 4, s.Max("foo", 3))
-	assert.Equal(t, 4, s.Get("foo"))
+	assert.Equal(t, uint64(4), s.Max("foo", 3))
+	assert.Equal(t, uint64(4), s.Get("foo"))
 
-	assert.Equal(t, 5, s.Max("foo", 5))
-	assert.Equal(t, 5, s.Get("foo"))
+	assert.Equal(t, uint64(5), s.Max("foo", 5))
+	assert.Equal(t, uint64(5), s.Get("foo"))
 }
 
 func TestInvalid(t *testing.T) {
 	s := stats.New("foo")
 
+	assert.Equal(t, uint64(0), s.Get("foo"))
 	assert.Panics(t, func() { s.Get("bar") })
 	assert.Panics(t, func() { s.Inc("bar") })
 	assert.Panics(t, func() { s.Max("bar", 1) })
-	assert.Equal(t, 0, s.Get("foo"))
+	assert.Equal(t, uint64(0), s.Get("foo"))
 }
 
 func TestSnapshot(t *testing.T) {
@@ -74,9 +75,9 @@ func TestSnapshot(t *testing.T) {
 	s.Inc("bar")
 
 	assert.ElementsMatch(t, []stats.CounterPair{
-		{"foo", 1},
-		{"bar", 2},
-		{"qaz", 0},
+		{Name: "foo", Value: uint64(1)},
+		{Name: "bar", Value: uint64(2)},
+		{Name: "qaz", Value: uint64(0)},
 	}, s.Snapshot())
 }
 


### PR DESCRIPTION
Profiling had revealed that a surprising amount of time was being spent in the filter converting rule indexes to the generated stat names. There was also a reasonable amount of time being spent waiting for the stats.Stats mutex. Using a stats.AnonStats instead solves both these issues.

AnonStats maintains a set of counters. It differs from Stats in the following ways:

- each counter is indexed by an integer instead of by name, avoiding the need for map lookups
- goroutine safety is achieved through the use of sync/atomic primitives instead of a global mutex. This is faster and avoids the problem of unnecessary synchronization between goroutines.
- counter values are uint64 instead of int

Stats now simply provide names for the index based counters contained in an embedded AnonStats. This removes the use of mutex in favour of the sync/atomic based approach of AnonStats.

CPU profiling for the filter and writer used to feature stats update and synchronization operations but these no longer show up as significant contributors to CPU utilization.

The micro-benchmark in the stats package is now ~78% faster.