### PR TITLE
Configuration cleanup

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,6 +8,12 @@
   version = "v0.3.0"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/c2h5oh/datasize"
+  packages = ["."]
+  revision = "4eba002a5eaea69cf8d235a388fc6b65ae68d2dd"
+
+[[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
@@ -116,6 +122,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "5d288d5d53cc70ca9f71ad0ffb1d09469862598882396f9cb697a92280b69def"
+  inputs-digest = "114fc9361dd5ed4f25efccba557d67d98a7af1524f8b049cadb07bacd5e6d078"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -23,3 +23,7 @@
 [[constraint]]
   branch = "master"
   name = "golang.org/x/perf"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/c2h5oh/datasize"

--- a/HACKING.md
+++ b/HACKING.md
@@ -40,7 +40,8 @@ UDP or HTTP.
 
 The `tools/watchmem` script can be used to monitor the memory usage of
 a program. This is useful for checking influx-spout for memory
-leaks. For example, to monitor the memory used by a influx-spout writer over time, run:
+leaks. For example, to monitor the memory used by a influx-spout
+writer over time, run:
 
 ```
 tools/watchmem writer-mem.dat influx-spout tools/writer.toml

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ batch_max_secs = 300
 # The maximum size that the listener should send at once to NATS.
 # This should be no bigger than the NATS server's max_payload setting (which
 # defaults to 1 MB).
-listener_batch_size = "1MB"
+batch_max_size = "1MB"
 
 # Maximum UDP socket receive buffer size. A higher value this increases the
 # peak inbound traffic the listener can handle at the cost of higher memory
@@ -162,7 +162,7 @@ pprof_port = 0
 ```
 
 The listener will batch up messages until one of the limits defined by the
-`batch`, `listener_batch_size` or `batch_max_secs` options is reached.
+`batch`, `batch_max_size` or `batch_max_secs` options is reached.
 
 
 ### HTTP Listener
@@ -198,7 +198,7 @@ batch_max_secs = 300
 # The maximum size that the listener should send at once to NATS.
 # This should be no bigger than the NATS server's max_payload setting (which
 # defaults to 1 MB).
-listener_batch_size = "1MB"
+batch_max_size = "1MB"
 
 # The HTTP listener will publish its own metrics to this NATS subject (for
 # consumption by the monitor).

--- a/README.md
+++ b/README.md
@@ -133,10 +133,10 @@ nats_address = "nats://localhost:4222"
 # Subject to publish received measurements on. This must be a list with one item.
 nats_subject = ["influx-spout"]
 
-# How many messages to collect before forwarding to the NATS server.
-# Increasing this number reduces NATS communication overhead but increases
-# latency.
-batch = 10
+# The maximum number of packets to receive before forwarding batched messages
+# to the NATS server. Increasing this number reduces NATS communication overhead
+# but increases latency.
+batch_max_count = 10
 
 # The maximum amount of time the listener will hold on to batched
 # lines. If this age is reached, the batch is written to NATS.
@@ -169,7 +169,7 @@ pprof_port = 0
 ```
 
 The listener will batch up messages until one of the limits defined by the
-`batch`, `batch_max_size` or `batch_max_age` options is reached.
+`batch_max_count`, `batch_max_size` or `batch_max_age` options is reached.
 
 
 ### HTTP Listener
@@ -193,10 +193,10 @@ nats_address = "nats://localhost:4222"
 # Subject to publish received measurements on. This must be a list with one item.
 nats_subject = ["influx-spout"]
 
-# How many messages to collect before forwarding to the NATS server.
-# Increasing this number reduces NATS communication overhead but increases
-# latency.
-batch = 10
+# The maximum number of inbound HTTP writes to batch before forwarding to the
+# NATS server. Increasing this number reduces NATS communication overhead but
+# increases latency.
+batch_max_count = 10
 
 # The maximum amount of time the listener will hold on to batched
 # lines. If this age is reached, the batch is written to NATS.
@@ -219,6 +219,10 @@ probe_port = 0
 default) to disable pprof support.
 pprof_port = 0
 ```
+
+
+The HTTP listener will batch up messages until one of the limits defined by the
+`batch_max_count`, `batch_max_size` or `batch_max_age` options is reached.
 
 ### Filter
 
@@ -342,10 +346,10 @@ influxdb_port = 8086
 # useful. Please set to an appropriate value.
 influxdb_dbname = "influx-spout-junk"
 
-# How many messages to collect before writing to InfluxDB.
-# Increasing this number reduces InfluxDB communication overhead but increases
-# latency.
-batch = 10
+# The maximum number of message chunks to collect before a write to InfluxDB
+# will be triggered. Increasing this number reduces communication overhead
+# with InfluxDB but increases latency.
+batch_max_count = 10
 
 # The maximum amount of message data a writer worker may collect. If
 # this limit is reached, a write to InfluxDB is performed.
@@ -380,7 +384,8 @@ pprof_port = 0
 ```
 
 A writer will batch up messages until one of the limits defined by the
-`batch`, `batch_max_size` or `batch_max_age` options is reached.
+`batch_max_count`, `batch_max_size` or `batch_max_age` options is
+reached.
 
 Writers can optionally include filter rules. When filter rules are configured
 measurements which don't match a rule will be dropped by the writer instead of

--- a/README.md
+++ b/README.md
@@ -91,12 +91,19 @@ to different influx-spout components to be shared.
 
 [TOML]: https://github.com/toml-lang/toml
 
-### Data Units
+### Byte Sizes
 
-All configuration options that define a bytes size are specified as a
+All configuration options that define a bytes size are specified using a
 string and contain an optional unit suffix. These examples are all
 valid ways to express the same byte size: `"2097152"`, `"2048KB"`, `"2MB"`,
 `"2M"` (single char), `"2mb"` (lower case), `"2 MB"` (space before unit).
+
+### Time Durations
+
+All configuration options that define a time duration are specified
+using a string and should use a unit suffix. These examples are all
+valid ways to express the same duration: `"7200s"`, `"120m"`,
+`"2h"`. Valid suffixes are "ns", "us", "ms", "s", "m" and "h".
 
 ## Modes
 
@@ -133,7 +140,7 @@ batch = 10
 
 # The maximum amount of time the listener will hold on to batched
 # lines. If this age is reached, the batch is written to NATS.
-batch_max_secs = 300
+batch_max_age = "5m"
 
 # The maximum size that the listener should send at once to NATS.
 # This should be no bigger than the NATS server's max_payload setting (which
@@ -162,7 +169,7 @@ pprof_port = 0
 ```
 
 The listener will batch up messages until one of the limits defined by the
-`batch`, `batch_max_size` or `batch_max_secs` options is reached.
+`batch`, `batch_max_size` or `batch_max_age` options is reached.
 
 
 ### HTTP Listener
@@ -193,7 +200,7 @@ batch = 10
 
 # The maximum amount of time the listener will hold on to batched
 # lines. If this age is reached, the batch is written to NATS.
-batch_max_secs = 300
+batch_max_age = "5m"
 
 # The maximum size that the listener should send at once to NATS.
 # This should be no bigger than the NATS server's max_payload setting (which
@@ -258,7 +265,7 @@ pprof_port = 0
 # Incoming metrics with timestamps ± this value from the current time will be
 # rejected. Metrics with timestamps that are significantly different from previously
 # written timestamps negatively impact InfluxDB performance.
-max_time_delta_secs = 600
+max_time_delta = "10m"
 
 # At least one rule should be defined. Rules are defined using TOML's table
 # syntax. The following examples show each rule type.
@@ -346,14 +353,14 @@ batch_max_size = "10MB"
 
 # The maximum amount of time a writer worker is allowed to hold on to collected
 # data. If this limit is reached, a write to InfluxDB is performed.
-batch_max_secs = 300
+batch_max_age = "5m"
 
 # The number of writer workers to spawn.
 workers = 8
 
-# The maximum number of seconds a writer will wait for an InfluxDB write to
+# The maximum amount of time a writer will wait for an InfluxDB write to
 # complete. Writes which time out will be dropped.
-write_timeout_secs = 30
+write_timeout = "30s"
 
 # The maximum size that the pending buffer for the NATS subject that the filter
 # is reading from may become. Measurements will be dropped if this limit is reached.
@@ -373,7 +380,7 @@ pprof_port = 0
 ```
 
 A writer will batch up messages until one of the limits defined by the
-`batch`, `batch_max_size` or `batch_max_secs` options is reached.
+`batch`, `batch_max_size` or `batch_max_age` options is reached.
 
 Writers can optionally include filter rules. When filter rules are configured
 measurements which don't match a rule will be dropped by the writer instead of

--- a/cmd/influx-spout/e2e_large_test.go
+++ b/cmd/influx-spout/e2e_large_test.go
@@ -195,7 +195,7 @@ func startListener(t *testing.T, fs afero.Fs) stoppable {
 mode = "listener"
 port = %d
 nats_address = "nats://localhost:%d"
-batch = 5
+batch_max_count = 5
 debug = true
 nats_subject_monitor = "monitor"
 probe_port = %d
@@ -207,7 +207,7 @@ func startHTTPListener(t *testing.T, fs afero.Fs) stoppable {
 mode = "listener_http"
 port = %d
 nats_address = "nats://localhost:%d"
-batch = 5
+batch_max_count = 5
 debug = true
 nats_subject_monitor = "monitor"
 probe_port = %d
@@ -236,7 +236,7 @@ nats_address = "nats://localhost:%d"
 nats_subject = ["system"]
 influxdb_port = %d
 influxdb_dbname = "%s"
-batch = 1
+batch_max_count = 1
 workers = 4
 debug = true
 nats_subject_monitor = "monitor"

--- a/config/config.go
+++ b/config/config.go
@@ -42,7 +42,7 @@ type Config struct {
 	InfluxDBAddress     string            `toml:"influxdb_address"`
 	InfluxDBPort        int               `toml:"influxdb_port"`
 	DBName              string            `toml:"influxdb_dbname"`
-	BatchMessages       int               `toml:"batch"`
+	BatchMaxCount       int               `toml:"batch_max_count"`
 	BatchMaxSize        datasize.ByteSize `toml:"batch_max_size"`
 	BatchMaxAge         Duration          `toml:"batch_max_age"`
 	Port                int               `toml:"port"`
@@ -73,7 +73,7 @@ func newDefaultConfig() *Config {
 		InfluxDBAddress:     "localhost",
 		InfluxDBPort:        8086,
 		DBName:              "influx-spout-junk",
-		BatchMessages:       10,
+		BatchMaxCount:       10,
 		BatchMaxAge:         Duration{5 * time.Minute},
 		Workers:             8,
 		WriteTimeout:        Duration{30 * time.Second},

--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/c2h5oh/datasize"
@@ -43,14 +44,14 @@ type Config struct {
 	DBName              string            `toml:"influxdb_dbname"`
 	BatchMessages       int               `toml:"batch"`
 	BatchMaxSize        datasize.ByteSize `toml:"batch_max_size"`
-	BatchMaxSecs        int               `toml:"batch_max_secs"`
+	BatchMaxAge         Duration          `toml:"batch_max_age"`
 	Port                int               `toml:"port"`
 	Workers             int               `toml:"workers"`
-	WriteTimeoutSecs    int               `toml:"write_timeout_secs"`
+	WriteTimeout        Duration          `toml:"write_timeout"`
 	ReadBufferSize      datasize.ByteSize `toml:"read_buffer_size"`
 	NATSMaxPendingSize  datasize.ByteSize `toml:"nats_max_pending_size"`
 	Rule                []Rule            `toml:"rule"`
-	MaxTimeDeltaSecs    int               `toml:"max_time_delta_secs"`
+	MaxTimeDelta        Duration          `toml:"max_time_delta"`
 	ProbePort           int               `toml:"probe_port"`
 	PprofPort           int               `toml:"pprof_port"`
 	Debug               bool              `toml:"debug"`
@@ -73,12 +74,12 @@ func newDefaultConfig() *Config {
 		InfluxDBPort:        8086,
 		DBName:              "influx-spout-junk",
 		BatchMessages:       10,
-		BatchMaxSecs:        300,
+		BatchMaxAge:         Duration{5 * time.Minute},
 		Workers:             8,
-		WriteTimeoutSecs:    30,
+		WriteTimeout:        Duration{30 * time.Second},
 		ReadBufferSize:      4 * datasize.MB,
 		NATSMaxPendingSize:  200 * datasize.MB,
-		MaxTimeDeltaSecs:    600,
+		MaxTimeDelta:        Duration{10 * time.Minute},
 		ProbePort:           0,
 		PprofPort:           0,
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 
 	"github.com/BurntSushi/toml"
+	"github.com/c2h5oh/datasize"
 	"github.com/spf13/afero"
 )
 
@@ -31,29 +32,29 @@ const commonFileName = "/etc/influx-spout.toml"
 // Config represents the configuration for a single influx-spout
 // component.
 type Config struct {
-	Name                string   `toml:"name"`
-	Mode                string   `toml:"mode"`
-	NATSAddress         string   `toml:"nats_address"`
-	NATSSubject         []string `toml:"nats_subject"`
-	NATSSubjectMonitor  string   `toml:"nats_subject_monitor"`
-	NATSSubjectJunkyard string   `toml:"nats_subject_junkyard"`
-	InfluxDBAddress     string   `toml:"influxdb_address"`
-	InfluxDBPort        int      `toml:"influxdb_port"`
-	DBName              string   `toml:"influxdb_dbname"`
-	BatchMessages       int      `toml:"batch"`
-	BatchMaxMB          int      `toml:"batch_max_mb"`
-	BatchMaxSecs        int      `toml:"batch_max_secs"`
-	Port                int      `toml:"port"`
-	Workers             int      `toml:"workers"`
-	WriteTimeoutSecs    int      `toml:"write_timeout_secs"`
-	ReadBufferBytes     int      `toml:"read_buffer_bytes"`
-	NATSPendingMaxMB    int      `toml:"nats_pending_max_mb"`
-	ListenerBatchBytes  int      `toml:"listener_batch_bytes"`
-	Rule                []Rule   `toml:"rule"`
-	MaxTimeDeltaSecs    int      `toml:"max_time_delta_secs"`
-	ProbePort           int      `toml:"probe_port"`
-	PprofPort           int      `toml:"pprof_port"`
-	Debug               bool     `toml:"debug"`
+	Name                string            `toml:"name"`
+	Mode                string            `toml:"mode"`
+	NATSAddress         string            `toml:"nats_address"`
+	NATSSubject         []string          `toml:"nats_subject"`
+	NATSSubjectMonitor  string            `toml:"nats_subject_monitor"`
+	NATSSubjectJunkyard string            `toml:"nats_subject_junkyard"`
+	InfluxDBAddress     string            `toml:"influxdb_address"`
+	InfluxDBPort        int               `toml:"influxdb_port"`
+	DBName              string            `toml:"influxdb_dbname"`
+	BatchMessages       int               `toml:"batch"`
+	BatchMaxSize        datasize.ByteSize `toml:"batch_max_size"`
+	BatchMaxSecs        int               `toml:"batch_max_secs"`
+	Port                int               `toml:"port"`
+	Workers             int               `toml:"workers"`
+	WriteTimeoutSecs    int               `toml:"write_timeout_secs"`
+	ReadBufferSize      datasize.ByteSize `toml:"read_buffer_size"`
+	NATSMaxPendingSize  datasize.ByteSize `toml:"nats_max_pending_size"`
+	ListenerBatchSize   datasize.ByteSize `toml:"listener_batch_size"`
+	Rule                []Rule            `toml:"rule"`
+	MaxTimeDeltaSecs    int               `toml:"max_time_delta_secs"`
+	ProbePort           int               `toml:"probe_port"`
+	PprofPort           int               `toml:"pprof_port"`
+	Debug               bool              `toml:"debug"`
 }
 
 // Rule contains the configuration for a single filter rule.
@@ -73,13 +74,13 @@ func newDefaultConfig() *Config {
 		InfluxDBPort:        8086,
 		DBName:              "influx-spout-junk",
 		BatchMessages:       10,
-		BatchMaxMB:          10,
+		BatchMaxSize:        10 * datasize.MB,
 		BatchMaxSecs:        300,
 		Workers:             8,
 		WriteTimeoutSecs:    30,
-		ReadBufferBytes:     4 * 1024 * 1024,
-		NATSPendingMaxMB:    200,
-		ListenerBatchBytes:  1024 * 1024,
+		ReadBufferSize:      4 * datasize.MB,
+		NATSMaxPendingSize:  200 * datasize.MB,
+		ListenerBatchSize:   1 * datasize.MB,
 		MaxTimeDeltaSecs:    600,
 		ProbePort:           0,
 		PprofPort:           0,

--- a/config/config_small_test.go
+++ b/config/config_small_test.go
@@ -35,7 +35,7 @@ func TestCorrectConfigFile(t *testing.T) {
 	const validConfigSample = `
 name = "thor"
 
-mode = "listener"
+mode = "writer"
 port = 10001
 
 nats_address = "nats://localhost:4222"
@@ -54,7 +54,6 @@ workers = 96
 write_timeout_secs = 32
 read_buffer_size = 43210
 nats_max_pending_size = "100MB"
-listener_batch_size = "4KB"
 max_time_delta_secs = 789
 
 probe_port = 6789
@@ -64,7 +63,7 @@ pprof_port = 5432
 	require.NoError(t, err, "Couldn't parse a valid config: %v\n", err)
 
 	assert.Equal(t, "thor", conf.Name, "Name must match")
-	assert.Equal(t, "listener", conf.Mode, "Mode must match")
+	assert.Equal(t, "writer", conf.Mode, "Mode must match")
 	assert.Equal(t, 10001, conf.Port, "Port must match")
 	assert.Equal(t, 10, conf.BatchMessages, "Batching must match")
 	assert.Equal(t, 5*datasize.MB, conf.BatchMaxSize)
@@ -73,7 +72,6 @@ pprof_port = 5432
 	assert.Equal(t, 32, conf.WriteTimeoutSecs, "WriteTimeoutSecs must match")
 	assert.Equal(t, 43210*datasize.B, conf.ReadBufferSize)
 	assert.Equal(t, 100*datasize.MB, conf.NATSMaxPendingSize)
-	assert.Equal(t, 4*datasize.KB, conf.ListenerBatchSize)
 	assert.Equal(t, 789, conf.MaxTimeDeltaSecs)
 
 	assert.Equal(t, 8086, conf.InfluxDBPort, "InfluxDB Port must match")
@@ -109,7 +107,6 @@ func TestAllDefaults(t *testing.T) {
 	assert.Equal(t, 30, conf.WriteTimeoutSecs)
 	assert.Equal(t, 4*datasize.MB, conf.ReadBufferSize)
 	assert.Equal(t, 200*datasize.MB, conf.NATSMaxPendingSize)
-	assert.Equal(t, 1*datasize.MB, conf.ListenerBatchSize)
 	assert.Equal(t, 600, conf.MaxTimeDeltaSecs)
 	assert.Equal(t, 0, conf.ProbePort)
 	assert.Equal(t, 0, conf.PprofPort)
@@ -133,6 +130,18 @@ func TestDefaultPortMonitor(t *testing.T) {
 	conf, err := parseConfig(`mode = "monitor"`)
 	require.NoError(t, err)
 	assert.Equal(t, 9331, conf.Port)
+}
+
+func TestDefaultListenerBatchSize(t *testing.T) {
+	conf, err := parseConfig(`mode = "listener"`)
+	require.NoError(t, err)
+	assert.Equal(t, 1*datasize.MB, conf.BatchMaxSize)
+}
+
+func TestDefaultHTTPListenerBatchSize(t *testing.T) {
+	conf, err := parseConfig(`mode = "listener_http"`)
+	require.NoError(t, err)
+	assert.Equal(t, 1*datasize.MB, conf.BatchMaxSize)
 }
 
 func TestNoMode(t *testing.T) {

--- a/config/config_small_test.go
+++ b/config/config_small_test.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/c2h5oh/datasize"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -46,14 +47,14 @@ influxdb_port = 8086
 influxdb_dbname = "junk_nats"
 
 batch = 10
-batch_max_mb = 5
+batch_max_size = "5m"
 batch_max_secs = 60
 workers = 96
 
 write_timeout_secs = 32
-read_buffer_bytes = 43210
-nats_pending_max_mb = 100
-listener_batch_bytes = 4096
+read_buffer_size = 43210
+nats_max_pending_size = "100MB"
+listener_batch_size = "4KB"
 max_time_delta_secs = 789
 
 probe_port = 6789
@@ -66,13 +67,13 @@ pprof_port = 5432
 	assert.Equal(t, "listener", conf.Mode, "Mode must match")
 	assert.Equal(t, 10001, conf.Port, "Port must match")
 	assert.Equal(t, 10, conf.BatchMessages, "Batching must match")
-	assert.Equal(t, 5, conf.BatchMaxMB)
+	assert.Equal(t, 5*datasize.MB, conf.BatchMaxSize)
 	assert.Equal(t, 60, conf.BatchMaxSecs)
 	assert.Equal(t, 96, conf.Workers)
 	assert.Equal(t, 32, conf.WriteTimeoutSecs, "WriteTimeoutSecs must match")
-	assert.Equal(t, 43210, conf.ReadBufferBytes)
-	assert.Equal(t, 100, conf.NATSPendingMaxMB)
-	assert.Equal(t, 4096, conf.ListenerBatchBytes)
+	assert.Equal(t, 43210*datasize.B, conf.ReadBufferSize)
+	assert.Equal(t, 100*datasize.MB, conf.NATSMaxPendingSize)
+	assert.Equal(t, 4*datasize.KB, conf.ListenerBatchSize)
 	assert.Equal(t, 789, conf.MaxTimeDeltaSecs)
 
 	assert.Equal(t, 8086, conf.InfluxDBPort, "InfluxDB Port must match")
@@ -100,15 +101,15 @@ func TestAllDefaults(t *testing.T) {
 	assert.Equal(t, 8086, conf.InfluxDBPort)
 	assert.Equal(t, "influx-spout-junk", conf.DBName)
 	assert.Equal(t, 10, conf.BatchMessages)
-	assert.Equal(t, 10, conf.BatchMaxMB)
+	assert.Equal(t, 10*datasize.MB, conf.BatchMaxSize)
 	assert.Equal(t, 300, conf.BatchMaxSecs)
 	assert.Equal(t, 0, conf.Port)
 	assert.Equal(t, "writer", conf.Mode)
 	assert.Equal(t, 8, conf.Workers)
 	assert.Equal(t, 30, conf.WriteTimeoutSecs)
-	assert.Equal(t, 4194304, conf.ReadBufferBytes)
-	assert.Equal(t, 200, conf.NATSPendingMaxMB)
-	assert.Equal(t, 1048576, conf.ListenerBatchBytes)
+	assert.Equal(t, 4*datasize.MB, conf.ReadBufferSize)
+	assert.Equal(t, 200*datasize.MB, conf.NATSMaxPendingSize)
+	assert.Equal(t, 1*datasize.MB, conf.ListenerBatchSize)
 	assert.Equal(t, 600, conf.MaxTimeDeltaSecs)
 	assert.Equal(t, 0, conf.ProbePort)
 	assert.Equal(t, 0, conf.PprofPort)

--- a/config/config_small_test.go
+++ b/config/config_small_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/c2h5oh/datasize"
 	"github.com/spf13/afero"
@@ -48,13 +49,13 @@ influxdb_dbname = "junk_nats"
 
 batch = 10
 batch_max_size = "5m"
-batch_max_secs = 60
+batch_max_age = "1m"
 workers = 96
 
-write_timeout_secs = 32
+write_timeout = "32s"
 read_buffer_size = 43210
 nats_max_pending_size = "100MB"
-max_time_delta_secs = 789
+max_time_delta = "789s"
 
 probe_port = 6789
 pprof_port = 5432
@@ -67,12 +68,12 @@ pprof_port = 5432
 	assert.Equal(t, 10001, conf.Port, "Port must match")
 	assert.Equal(t, 10, conf.BatchMessages, "Batching must match")
 	assert.Equal(t, 5*datasize.MB, conf.BatchMaxSize)
-	assert.Equal(t, 60, conf.BatchMaxSecs)
+	assert.Equal(t, time.Minute, conf.BatchMaxAge.Duration)
 	assert.Equal(t, 96, conf.Workers)
-	assert.Equal(t, 32, conf.WriteTimeoutSecs, "WriteTimeoutSecs must match")
+	assert.Equal(t, 32*time.Second, conf.WriteTimeout.Duration)
 	assert.Equal(t, 43210*datasize.B, conf.ReadBufferSize)
 	assert.Equal(t, 100*datasize.MB, conf.NATSMaxPendingSize)
-	assert.Equal(t, 789, conf.MaxTimeDeltaSecs)
+	assert.Equal(t, 789*time.Second, conf.MaxTimeDelta.Duration)
 
 	assert.Equal(t, 8086, conf.InfluxDBPort, "InfluxDB Port must match")
 	assert.Equal(t, "junk_nats", conf.DBName, "InfluxDB DBname must match")
@@ -100,14 +101,14 @@ func TestAllDefaults(t *testing.T) {
 	assert.Equal(t, "influx-spout-junk", conf.DBName)
 	assert.Equal(t, 10, conf.BatchMessages)
 	assert.Equal(t, 10*datasize.MB, conf.BatchMaxSize)
-	assert.Equal(t, 300, conf.BatchMaxSecs)
+	assert.Equal(t, 5*time.Minute, conf.BatchMaxAge.Duration)
 	assert.Equal(t, 0, conf.Port)
 	assert.Equal(t, "writer", conf.Mode)
 	assert.Equal(t, 8, conf.Workers)
-	assert.Equal(t, 30, conf.WriteTimeoutSecs)
+	assert.Equal(t, 30*time.Second, conf.WriteTimeout.Duration)
 	assert.Equal(t, 4*datasize.MB, conf.ReadBufferSize)
 	assert.Equal(t, 200*datasize.MB, conf.NATSMaxPendingSize)
-	assert.Equal(t, 600, conf.MaxTimeDeltaSecs)
+	assert.Equal(t, 10*time.Minute, conf.MaxTimeDelta.Duration)
 	assert.Equal(t, 0, conf.ProbePort)
 	assert.Equal(t, 0, conf.PprofPort)
 	assert.Equal(t, false, conf.Debug)

--- a/config/config_small_test.go
+++ b/config/config_small_test.go
@@ -47,7 +47,7 @@ influxdb_address = "localhost"
 influxdb_port = 8086
 influxdb_dbname = "junk_nats"
 
-batch = 10
+batch_max_count = 10
 batch_max_size = "5m"
 batch_max_age = "1m"
 workers = 96
@@ -66,7 +66,7 @@ pprof_port = 5432
 	assert.Equal(t, "thor", conf.Name, "Name must match")
 	assert.Equal(t, "writer", conf.Mode, "Mode must match")
 	assert.Equal(t, 10001, conf.Port, "Port must match")
-	assert.Equal(t, 10, conf.BatchMessages, "Batching must match")
+	assert.Equal(t, 10, conf.BatchMaxCount, "Batching must match")
 	assert.Equal(t, 5*datasize.MB, conf.BatchMaxSize)
 	assert.Equal(t, time.Minute, conf.BatchMaxAge.Duration)
 	assert.Equal(t, 96, conf.Workers)
@@ -99,7 +99,7 @@ func TestAllDefaults(t *testing.T) {
 	assert.Equal(t, "localhost", conf.InfluxDBAddress)
 	assert.Equal(t, 8086, conf.InfluxDBPort)
 	assert.Equal(t, "influx-spout-junk", conf.DBName)
-	assert.Equal(t, 10, conf.BatchMessages)
+	assert.Equal(t, 10, conf.BatchMaxCount)
 	assert.Equal(t, 10*datasize.MB, conf.BatchMaxSize)
 	assert.Equal(t, 5*time.Minute, conf.BatchMaxAge.Duration)
 	assert.Equal(t, 0, conf.Port)
@@ -200,12 +200,12 @@ subject = "world-subject"
 
 func TestCommonOverlay(t *testing.T) {
 	const commonConfig = `
-batch = 50
+batch_max_count = 50
 influxdb_dbname = "massive"
 `
 	const specificConfig = `
 mode = "listener"
-batch = 100
+batch_max_count = 100
 debug = true
 `
 	Fs = afero.NewMemMapFs()
@@ -216,7 +216,7 @@ debug = true
 	require.NoError(t, err)
 
 	assert.Equal(t, "listener", conf.Mode)   // only set in specific config
-	assert.Equal(t, 100, conf.BatchMessages) // overridden in specific config
+	assert.Equal(t, 100, conf.BatchMaxCount) // overridden in specific config
 	assert.Equal(t, "massive", conf.DBName)  // only set in common config
 }
 
@@ -226,7 +226,7 @@ wat
 `
 	const specificConfig = `
 mode = "listener"
-batch = 100
+batch_max_count = 100
 debug = true
 `
 

--- a/config/duration.go
+++ b/config/duration.go
@@ -1,0 +1,31 @@
+// Copyright 2018 Jump Trading
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "time"
+
+// Duration is used to support parsing of time durations directly into
+// time.Duration instances. Use the embedded Duration field to access
+// to the underlying time.Duration.
+type Duration struct {
+	time.Duration
+}
+
+// UnmarshalText implements the TextUnmarshaler interface.
+func (d *Duration) UnmarshalText(text []byte) error {
+	var err error
+	d.Duration, err = time.ParseDuration(string(text))
+	return err
+}

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -98,7 +98,7 @@ func StartFilter(conf *config.Config) (_ *Filter, err error) {
 	if err != nil {
 		return nil, fmt.Errorf("NATS: failed to subscribe: %v", err)
 	}
-	if err := f.sub.SetPendingLimits(-1, conf.NATSPendingMaxMB*1024*1024); err != nil {
+	if err := f.sub.SetPendingLimits(-1, int(conf.NATSMaxPendingSize.Bytes())); err != nil {
 		return nil, fmt.Errorf("NATS: failed to set pending limits: %v", err)
 	}
 

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -70,7 +70,7 @@ func StartFilter(conf *config.Config) (_ *Filter, err error) {
 	jobs := make(chan []byte, 1024)
 	for i := 0; i < f.c.Workers; i++ {
 		w, err := newWorker(
-			f.c.MaxTimeDeltaSecs,
+			f.c.MaxTimeDelta.Duration,
 			rules,
 			st,
 			ruleSt,

--- a/filter/filter_medium_test.go
+++ b/filter/filter_medium_test.go
@@ -42,7 +42,7 @@ func testConfig() *config.Config {
 		NATSSubjectJunkyard: "filter-junkyard",
 		NATSMaxPendingSize:  32 * datasize.MB,
 		Workers:             1,
-		MaxTimeDeltaSecs:    600,
+		MaxTimeDelta:        config.Duration{10 * time.Minute},
 		Rule: []config.Rule{{
 			Rtype:   "basic",
 			Match:   "hello",
@@ -123,7 +123,7 @@ func TestInvalidTimeStamps(t *testing.T) {
 	defer gnatsd.Shutdown()
 
 	conf := testConfig()
-	conf.MaxTimeDeltaSecs = 10
+	conf.MaxTimeDelta = config.Duration{10 * time.Second}
 
 	filter := startFilter(t, conf)
 	defer filter.Stop()

--- a/filter/filter_medium_test.go
+++ b/filter/filter_medium_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/c2h5oh/datasize"
 	"github.com/nats-io/go-nats"
 	"github.com/stretchr/testify/require"
 
@@ -39,7 +40,7 @@ func testConfig() *config.Config {
 		NATSSubject:         []string{"filter-test"},
 		NATSSubjectMonitor:  "filter-test-monitor",
 		NATSSubjectJunkyard: "filter-junkyard",
-		NATSPendingMaxMB:    32,
+		NATSMaxPendingSize:  32 * datasize.MB,
 		Workers:             1,
 		MaxTimeDeltaSecs:    600,
 		Rule: []config.Rule{{

--- a/filter/worker.go
+++ b/filter/worker.go
@@ -26,7 +26,7 @@ import (
 )
 
 type worker struct {
-	maxTsDeltaNs int64
+	maxTimeDelta time.Duration
 	rules        *RuleSet
 	st           *stats.Stats
 	ruleSt       *stats.AnonStats
@@ -38,7 +38,7 @@ type worker struct {
 }
 
 func newWorker(
-	maxTsDeltaSecs int,
+	maxTimeDelta time.Duration,
 	rules *RuleSet,
 	st *stats.Stats,
 	ruleSt *stats.AnonStats,
@@ -58,7 +58,7 @@ func newWorker(
 	}
 
 	return &worker{
-		maxTsDeltaNs: int64(maxTsDeltaSecs) * 1e9,
+		maxTimeDelta: maxTimeDelta,
 		rules:        rules,
 		st:           st,
 		ruleSt:       ruleSt,
@@ -87,8 +87,8 @@ func (w *worker) run(jobs <-chan []byte, stop <-chan struct{}, wg *sync.WaitGrou
 
 func (w *worker) processBatch(batch []byte) {
 	now := time.Now().UnixNano()
-	minTs := now - w.maxTsDeltaNs
-	maxTs := now + w.maxTsDeltaNs
+	minTs := now - int64(w.maxTimeDelta)
+	maxTs := now + int64(w.maxTimeDelta)
 
 	for _, line := range bytes.SplitAfter(batch, []byte("\n")) {
 		if len(line) == 0 {

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -65,7 +65,7 @@ func StartListener(c *config.Config) (_ *Listener, err error) {
 		}
 	}()
 
-	sc, err := listener.setupUDP(c.ReadBufferBytes)
+	sc, err := listener.setupUDP(int(c.ReadBufferSize.Bytes()))
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +138,7 @@ func newListener(c *config.Config) (*Listener, error) {
 			statFailedNATSPublish,
 		),
 		probes:      probes.Listen(c.ProbePort),
-		batch:       batch.New(c.ListenerBatchBytes),
+		batch:       batch.New(int(c.ListenerBatchSize.Bytes())),
 		maxBatchAge: time.Duration(c.BatchMaxSecs) * time.Second,
 	}
 
@@ -389,7 +389,7 @@ func (l *Listener) shouldSend() bool {
 	// If the batch size is within a (maximum) UDP datagram of the
 	// configured target batch size, then force a send to avoid
 	// growing the batch unnecessarily (allocations hurt performance).
-	if l.c.ListenerBatchBytes-l.batch.Size() <= maxUDPDatagramSize {
+	if int(l.c.ListenerBatchSize.Bytes())-l.batch.Size() <= maxUDPDatagramSize {
 		return true
 	}
 

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -376,7 +376,7 @@ func (l *Listener) maybeSendBatch() {
 }
 
 func (l *Listener) shouldSend() bool {
-	if l.batch.Writes() >= l.c.BatchMessages {
+	if l.batch.Writes() >= l.c.BatchMaxCount {
 		return true
 	}
 

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -138,7 +138,7 @@ func newListener(c *config.Config) (*Listener, error) {
 			statFailedNATSPublish,
 		),
 		probes:      probes.Listen(c.ProbePort),
-		batch:       batch.New(int(c.ListenerBatchSize.Bytes())),
+		batch:       batch.New(int(c.BatchMaxSize.Bytes())),
 		maxBatchAge: time.Duration(c.BatchMaxSecs) * time.Second,
 	}
 
@@ -389,7 +389,7 @@ func (l *Listener) shouldSend() bool {
 	// If the batch size is within a (maximum) UDP datagram of the
 	// configured target batch size, then force a send to avoid
 	// growing the batch unnecessarily (allocations hurt performance).
-	if int(l.c.ListenerBatchSize.Bytes())-l.batch.Size() <= maxUDPDatagramSize {
+	if int(l.c.BatchMaxSize.Bytes())-l.batch.Size() <= maxUDPDatagramSize {
 		return true
 	}
 

--- a/listener/listener_medium_test.go
+++ b/listener/listener_medium_test.go
@@ -70,7 +70,7 @@ func testConfig() *config.Config {
 		NATSSubjectMonitor: natsMonitorSubject,
 		BatchMessages:      1,
 		BatchMaxSize:       1 * datasize.MB,
-		BatchMaxSecs:       60,
+		BatchMaxAge:        config.Duration{60 * time.Second},
 		ReadBufferSize:     4 * datasize.MB,
 
 		Port:      listenPort,
@@ -191,7 +191,7 @@ func TestBatchAge(t *testing.T) {
 	// batch age expiry.
 	conf := testConfig()
 	conf.BatchMessages = 9999
-	conf.BatchMaxSecs = 1
+	conf.BatchMaxAge = config.Duration{time.Second}
 
 	listener := startListener(t, conf)
 	defer listener.Stop()
@@ -381,7 +381,7 @@ func TestBatchAgeHTTPListener(t *testing.T) {
 	// batch age expiry.
 	conf := testConfig()
 	conf.BatchMessages = 9999
-	conf.BatchMaxSecs = 1
+	conf.BatchMaxAge = config.Duration{time.Second}
 	listener := startHTTPListener(t, conf)
 	defer listener.Stop()
 

--- a/listener/listener_medium_test.go
+++ b/listener/listener_medium_test.go
@@ -68,8 +68,8 @@ func testConfig() *config.Config {
 		NATSAddress:        natsAddress,
 		NATSSubject:        []string{natsSubject},
 		NATSSubjectMonitor: natsMonitorSubject,
-		ListenerBatchSize:  1 * datasize.MB,
 		BatchMessages:      1,
+		BatchMaxSize:       1 * datasize.MB,
 		BatchMaxSecs:       60,
 		ReadBufferSize:     4 * datasize.MB,
 
@@ -245,7 +245,7 @@ func TestHTTPListenerBigPOST(t *testing.T) {
 	defer s.Shutdown()
 
 	conf := testConfig()
-	conf.ListenerBatchSize = 1024 * datasize.B
+	conf.BatchMaxSize = 1024 * datasize.B
 	// Use a batch size > 1. Even though a single write will be made,
 	// the batch should still get sent because the buffer size limit
 	// is exceeded.
@@ -264,7 +264,7 @@ func TestHTTPListenerBigPOST(t *testing.T) {
 
 	// Send a post that's bigger than the configured batch size. This
 	// will force the batch buffer to grow.
-	buf := make([]byte, conf.ListenerBatchSize.Bytes()+200)
+	buf := make([]byte, conf.BatchMaxSize.Bytes()+200)
 
 	url := fmt.Sprintf("http://localhost:%d/write", listenPort)
 	_, err = http.Post(url, "text/plain", bytes.NewBuffer(buf))

--- a/listener/listener_medium_test.go
+++ b/listener/listener_medium_test.go
@@ -68,7 +68,7 @@ func testConfig() *config.Config {
 		NATSAddress:        natsAddress,
 		NATSSubject:        []string{natsSubject},
 		NATSSubjectMonitor: natsMonitorSubject,
-		BatchMessages:      1,
+		BatchMaxCount:      1,
 		BatchMaxSize:       1 * datasize.MB,
 		BatchMaxAge:        config.Duration{60 * time.Second},
 		ReadBufferSize:     4 * datasize.MB,
@@ -83,7 +83,7 @@ func TestBatching(t *testing.T) {
 	defer s.Shutdown()
 
 	conf := testConfig()
-	conf.BatchMessages = numLines // batch messages into one packet
+	conf.BatchMaxCount = numLines // batch messages into one packet
 
 	listener := startListener(t, conf)
 	defer listener.Stop()
@@ -145,7 +145,7 @@ func TestBatchBufferFull(t *testing.T) {
 	conf := testConfig()
 	// Set batch size high so that the batch will only send due to the
 	// batch buffer filling up.
-	conf.BatchMessages = 99999
+	conf.BatchMaxCount = 99999
 
 	listener := startListener(t, conf)
 	defer listener.Stop()
@@ -179,7 +179,7 @@ loop:
 
 	// Ensure that batch was output because batch size limit was
 	// reached, not the message count.
-	assert.True(t, writeCount < conf.BatchMessages,
+	assert.True(t, writeCount < conf.BatchMaxCount,
 		fmt.Sprintf("writeCount = %d", writeCount))
 }
 
@@ -190,7 +190,7 @@ func TestBatchAge(t *testing.T) {
 	// Set config so that a small write will only come through due to
 	// batch age expiry.
 	conf := testConfig()
-	conf.BatchMessages = 9999
+	conf.BatchMaxCount = 9999
 	conf.BatchMaxAge = config.Duration{time.Second}
 
 	listener := startListener(t, conf)
@@ -249,7 +249,7 @@ func TestHTTPListenerBigPOST(t *testing.T) {
 	// Use a batch size > 1. Even though a single write will be made,
 	// the batch should still get sent because the buffer size limit
 	// is exceeded.
-	conf.BatchMessages = 10
+	conf.BatchMaxCount = 10
 
 	listener, err := StartHTTPListener(conf)
 	require.NoError(t, err)
@@ -380,7 +380,7 @@ func TestBatchAgeHTTPListener(t *testing.T) {
 	// Set config so that a small write will only come through due to
 	// batch age expiry.
 	conf := testConfig()
-	conf.BatchMessages = 9999
+	conf.BatchMaxCount = 9999
 	conf.BatchMaxAge = config.Duration{time.Second}
 	listener := startHTTPListener(t, conf)
 	defer listener.Stop()

--- a/tools/listener.toml
+++ b/tools/listener.toml
@@ -4,7 +4,7 @@ nats_subject = ["spout"]
 nats_subject_monitor = "monitor"
 port = 9999
 
-batch = 100
+batch_max_count = 100
 
 debug = true
 pprof_port = 4000

--- a/tools/listener_http.toml
+++ b/tools/listener_http.toml
@@ -4,7 +4,7 @@ nats_subject = ["spout"]
 nats_subject_monitor = "monitor"
 port = 9998
 
-batch = 100
+batch_max_count = 100
 
 debug = true
 pprof_port = 4001

--- a/tools/writer.toml
+++ b/tools/writer.toml
@@ -9,7 +9,7 @@ influxdb_port = 8086
 influxdb_dbname = "spout"
 
 workers = 10
-batch = 10
+batch_max_count = 10
 batch_max_size = "100MB"
 write_timeout = "10s"
 

--- a/tools/writer.toml
+++ b/tools/writer.toml
@@ -10,8 +10,8 @@ influxdb_dbname = "spout"
 
 workers = 10
 batch = 10
-batch_max_mb = 100
-write_timeout_secs = 10
+batch_max_size = "100MB"
+write_timeout = "10s"
 
 debug = true
 pprof_port = 4003

--- a/vendor/github.com/c2h5oh/datasize/.gitignore
+++ b/vendor/github.com/c2h5oh/datasize/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/c2h5oh/datasize/.travis.yml
+++ b/vendor/github.com/c2h5oh/datasize/.travis.yml
@@ -1,0 +1,11 @@
+sudo: false
+
+language: go
+go:
+  - 1.4
+  - 1.5
+  - 1.6
+  - tip
+
+script:
+  - go test -v

--- a/vendor/github.com/c2h5oh/datasize/LICENSE
+++ b/vendor/github.com/c2h5oh/datasize/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Maciej Lisiewski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/c2h5oh/datasize/README.md
+++ b/vendor/github.com/c2h5oh/datasize/README.md
@@ -1,0 +1,66 @@
+# datasize [![Build Status](https://travis-ci.org/c2h5oh/datasize.svg?branch=master)](https://travis-ci.org/c2h5oh/datasize)
+
+Golang helpers for data sizes
+
+
+### Constants
+Just like `time` package provides `time.Second`, `time.Day` constants `datasize` provides:
+* `datasize.B` 1 byte
+* `datasize.KB` 1 kilobyte
+* `datasize.MB` 1 megabyte
+* `datasize.GB` 1 gigabyte
+* `datasize.TB` 1 terabyte
+* `datasize.PB` 1 petabyte
+* `datasize.EB` 1 exabyte
+
+### Helpers
+Just like `time` package provides `duration.Nanoseconds() uint64 `, `duration.Hours() float64` helpers `datasize` has
+* `ByteSize.Bytes() uint64`
+* `ByteSize.Kilobytes() float4`
+* `ByteSize.Megabytes() float64`
+* `ByteSize.Gigabytes() float64`
+* `ByteSize.Terabytes() float64`
+* `ByteSize.Petebytes() float64`
+* `ByteSize.Exabytes() float64`
+
+Warning: see limitations at the end of this document about a possible precission loss
+
+### Parsing strings
+`datasize.ByteSize` implements `TextUnmarshaler` interface and will automatically parse human readable strings into correct values where it is used:
+* `"10 MB"` -> `10* datasize.MB`
+* `"10240 g"` -> `10 * datasize.TB`
+* `"2000"` -> `2000 * datasize.B`
+* `"1tB"` -> `datasize.TB`
+* `"5 peta"` -> `5 * datasize.PB`
+* `"28 kilobytes"` -> `28 * datasize.KB`
+* `"1 gigabyte"` -> `1 * datasize.GB`
+
+You can also do it manually:
+```go
+var v datasize.ByteSize
+err := v.UnmarshalText([]byte("100 mb"))
+```
+
+### Printing
+`Bytesize.String()` uses largest unit allowing an integer value:
+    * `(102400 * datasize.MB).String()` -> `"100GB"`
+    * `(datasize.MB + datasize.KB).String()` -> `"1025KB"`
+
+Use `%d` format string to get value in bytes without a unit
+
+### JSON and other encoding
+Both `TextMarshaler` and `TextUnmarshaler` interfaces are implemented - JSON will just work. Other encoders will work provided they use those interfaces.
+
+### Human readable
+`ByteSize.HumanReadable()` or `ByteSize.HR()` returns a string with 1-3 digits, followed by 1 decimal place, a space and unit big enough to get 1-3 digits
+
+    * `(102400 * datasize.MB).String()` -> `"100.0 GB"`
+    * `(datasize.MB + 512 * datasize.KB).String()` -> `"1.5 MB"`
+
+### Limitations
+* The underlying data type for `data.ByteSize` is `uint64`, so values outside of 0 to 2^64-1 range will overflow
+* size helper functions (like `ByteSize.Kilobytes()`) return `float64`, which can't represent all possible values of `uint64` accurately:
+  * if the returned value is supposed to have no fraction (ie `(10 * datasize.MB).Kilobytes()`) accuracy loss happens when value is more than 2^53 larger than unit: `.Kilobytes()` over 8 petabytes, `.Megabytes()` over 8 exabytes
+  * if the returned value is supposed to have a fraction (ie `(datasize.PB + datasize.B).Megabytes()`) in addition to the above note accuracy loss may occur in fractional part too - larger integer part leaves fewer bytes to store fractional part, the smaller the remainder vs unit the move bytes are required to store the fractional part
+* Parsing a string with `Mb`, `Tb`, etc units will return a syntax error, because capital followed by lower case is commonly used for bits, not bytes
+* Parsing a string with value exceeding 2^64-1 bytes will return 2^64-1 and an out of range error

--- a/vendor/github.com/c2h5oh/datasize/datasize.go
+++ b/vendor/github.com/c2h5oh/datasize/datasize.go
@@ -1,0 +1,217 @@
+package datasize
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type ByteSize uint64
+
+const (
+	B  ByteSize = 1
+	KB          = B << 10
+	MB          = KB << 10
+	GB          = MB << 10
+	TB          = GB << 10
+	PB          = TB << 10
+	EB          = PB << 10
+
+	fnUnmarshalText string = "UnmarshalText"
+	maxUint64       uint64 = (1 << 64) - 1
+	cutoff          uint64 = maxUint64 / 10
+)
+
+var ErrBits = errors.New("unit with capital unit prefix and lower case unit (b) - bits, not bytes ")
+
+func (b ByteSize) Bytes() uint64 {
+	return uint64(b)
+}
+
+func (b ByteSize) KBytes() float64 {
+	v := b / KB
+	r := b % KB
+	return float64(v) + float64(r)/float64(KB)
+}
+
+func (b ByteSize) MBytes() float64 {
+	v := b / MB
+	r := b % MB
+	return float64(v) + float64(r)/float64(MB)
+}
+
+func (b ByteSize) GBytes() float64 {
+	v := b / GB
+	r := b % GB
+	return float64(v) + float64(r)/float64(GB)
+}
+
+func (b ByteSize) TBytes() float64 {
+	v := b / TB
+	r := b % TB
+	return float64(v) + float64(r)/float64(TB)
+}
+
+func (b ByteSize) PBytes() float64 {
+	v := b / PB
+	r := b % PB
+	return float64(v) + float64(r)/float64(PB)
+}
+
+func (b ByteSize) EBytes() float64 {
+	v := b / EB
+	r := b % EB
+	return float64(v) + float64(r)/float64(EB)
+}
+
+func (b ByteSize) String() string {
+	switch {
+	case b == 0:
+		return fmt.Sprint("0B")
+	case b%EB == 0:
+		return fmt.Sprintf("%dEB", b/EB)
+	case b%PB == 0:
+		return fmt.Sprintf("%dPB", b/PB)
+	case b%TB == 0:
+		return fmt.Sprintf("%dTB", b/TB)
+	case b%GB == 0:
+		return fmt.Sprintf("%dGB", b/GB)
+	case b%MB == 0:
+		return fmt.Sprintf("%dMB", b/MB)
+	case b%KB == 0:
+		return fmt.Sprintf("%dKB", b/KB)
+	default:
+		return fmt.Sprintf("%dB", b)
+	}
+}
+
+func (b ByteSize) HR() string {
+	return b.HumanReadable()
+}
+
+func (b ByteSize) HumanReadable() string {
+	switch {
+	case b > EB:
+		return fmt.Sprintf("%.1f EB", b.EBytes())
+	case b > PB:
+		return fmt.Sprintf("%.1f PB", b.PBytes())
+	case b > TB:
+		return fmt.Sprintf("%.1f TB", b.TBytes())
+	case b > GB:
+		return fmt.Sprintf("%.1f GB", b.GBytes())
+	case b > MB:
+		return fmt.Sprintf("%.1f MB", b.MBytes())
+	case b > KB:
+		return fmt.Sprintf("%.1f KB", b.KBytes())
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}
+
+func (b ByteSize) MarshalText() ([]byte, error) {
+	return []byte(b.String()), nil
+}
+
+func (b *ByteSize) UnmarshalText(t []byte) error {
+	var val uint64
+	var unit string
+
+	// copy for error message
+	t0 := t
+
+	var c byte
+	var i int
+
+ParseLoop:
+	for i < len(t) {
+		c = t[i]
+		switch {
+		case '0' <= c && c <= '9':
+			if val > cutoff {
+				goto Overflow
+			}
+
+			c = c - '0'
+			val *= 10
+
+			if val > val+uint64(c) {
+				// val+v overflows
+				goto Overflow
+			}
+			val += uint64(c)
+			i++
+
+		default:
+			if i == 0 {
+				goto SyntaxError
+			}
+			break ParseLoop
+		}
+	}
+
+	unit = strings.TrimSpace(string(t[i:]))
+	switch unit {
+	case "Kb", "Mb", "Gb", "Tb", "Pb", "Eb":
+		goto BitsError
+	}
+	unit = strings.ToLower(unit)
+	switch unit {
+	case "", "b", "byte":
+		// do nothing - already in bytes
+
+	case "k", "kb", "kilo", "kilobyte", "kilobytes":
+		if val > maxUint64/uint64(KB) {
+			goto Overflow
+		}
+		val *= uint64(KB)
+
+	case "m", "mb", "mega", "megabyte", "megabytes":
+		if val > maxUint64/uint64(MB) {
+			goto Overflow
+		}
+		val *= uint64(MB)
+
+	case "g", "gb", "giga", "gigabyte", "gigabytes":
+		if val > maxUint64/uint64(GB) {
+			goto Overflow
+		}
+		val *= uint64(GB)
+
+	case "t", "tb", "tera", "terabyte", "terabytes":
+		if val > maxUint64/uint64(TB) {
+			goto Overflow
+		}
+		val *= uint64(TB)
+
+	case "p", "pb", "peta", "petabyte", "petabytes":
+		if val > maxUint64/uint64(PB) {
+			goto Overflow
+		}
+		val *= uint64(PB)
+
+	case "E", "EB", "e", "eb", "eB":
+		if val > maxUint64/uint64(EB) {
+			goto Overflow
+		}
+		val *= uint64(EB)
+
+	default:
+		goto SyntaxError
+	}
+
+	*b = ByteSize(val)
+	return nil
+
+Overflow:
+	*b = ByteSize(maxUint64)
+	return &strconv.NumError{fnUnmarshalText, string(t0), strconv.ErrRange}
+
+SyntaxError:
+	*b = 0
+	return &strconv.NumError{fnUnmarshalText, string(t0), strconv.ErrSyntax}
+
+BitsError:
+	*b = 0
+	return &strconv.NumError{fnUnmarshalText, string(t0), ErrBits}
+}

--- a/vendor/github.com/c2h5oh/datasize/datasize_test.go
+++ b/vendor/github.com/c2h5oh/datasize/datasize_test.go
@@ -1,0 +1,73 @@
+package datasize_test
+
+import (
+	"testing"
+
+	. "github.com/c2h5oh/datasize"
+)
+
+func TestMarshalText(t *testing.T) {
+	table := []struct {
+		in  ByteSize
+		out string
+	}{
+		{0, "0B"},
+		{B, "1B"},
+		{KB, "1KB"},
+		{MB, "1MB"},
+		{GB, "1GB"},
+		{TB, "1TB"},
+		{PB, "1PB"},
+		{EB, "1EB"},
+		{400 * TB, "400TB"},
+		{2048 * MB, "2GB"},
+		{B + KB, "1025B"},
+		{MB + 20*KB, "1044KB"},
+		{100*MB + KB, "102401KB"},
+	}
+
+	for _, tt := range table {
+		b, _ := tt.in.MarshalText()
+		s := string(b)
+
+		if s != tt.out {
+			t.Errorf("MarshalText(%d) => %s, want %s", tt.in, s, tt.out)
+		}
+	}
+}
+
+func TestUnmarshalText(t *testing.T) {
+	table := []struct {
+		in  string
+		err bool
+		out ByteSize
+	}{
+		{"0", false, ByteSize(0)},
+		{"0B", false, ByteSize(0)},
+		{"0 KB", false, ByteSize(0)},
+		{"1", false, B},
+		{"1K", false, KB},
+		{"2MB", false, 2 * MB},
+		{"5 GB", false, 5 * GB},
+		{"20480 G", false, 20 * TB},
+		{"50 eB", true, ByteSize((1 << 64) - 1)},
+		{"200000 pb", true, ByteSize((1 << 64) - 1)},
+		{"10 Mb", true, ByteSize(0)},
+		{"g", true, ByteSize(0)},
+		{"10 kB ", false, 10 * KB},
+		{"10 kBs ", true, ByteSize(0)},
+	}
+
+	for _, tt := range table {
+		var s ByteSize
+		err := s.UnmarshalText([]byte(tt.in))
+
+		if (err != nil) != tt.err {
+			t.Errorf("UnmarshalText(%s) => %v, want no error", tt.in, err)
+		}
+
+		if s != tt.out {
+			t.Errorf("UnmarshalText(%s) => %d bytes, want %d bytes", tt.in, s, tt.out)
+		}
+	}
+}

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -208,7 +208,7 @@ func (w *Writer) filterLine(line []byte) bool {
 }
 
 func (w *Writer) shouldSend(batch *batch.Batch) bool {
-	return batch.Writes() >= w.c.BatchMessages ||
+	return batch.Writes() >= w.c.BatchMaxCount ||
 		uint64(batch.Size()) >= w.c.BatchMaxSize.Bytes() ||
 		batch.Age() >= w.c.BatchMaxAge.Duration
 }

--- a/writer/writer_medium_test.go
+++ b/writer/writer_medium_test.go
@@ -50,7 +50,7 @@ func testConfig() *config.Config {
 		InfluxDBAddress:    "localhost",
 		InfluxDBPort:       influxPort,
 		DBName:             "metrics",
-		BatchMessages:      1,
+		BatchMaxCount:      1,
 		BatchMaxSize:       10 * datasize.MB,
 		BatchMaxAge:        config.Duration{5 * time.Minute},
 		Port:               influxPort,
@@ -122,7 +122,7 @@ func TestBatchMBLimit(t *testing.T) {
 	// No filter rules.
 	conf := testConfig()
 	conf.Workers = 1
-	conf.BatchMessages = 9999
+	conf.BatchMaxCount = 9999
 	conf.BatchMaxSize = 1 * datasize.MB
 	w := startWriter(t, conf)
 	defer w.Stop()
@@ -159,7 +159,7 @@ func TestBatchTimeLimit(t *testing.T) {
 	// No filter rules.
 	conf := testConfig()
 	conf.Workers = 1
-	conf.BatchMessages = 9999
+	conf.BatchMaxCount = 9999
 	conf.BatchMaxAge = config.Duration{time.Second}
 	w := startWriter(t, conf)
 	defer w.Stop()

--- a/writer/writer_medium_test.go
+++ b/writer/writer_medium_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/c2h5oh/datasize"
 	"github.com/nats-io/go-nats"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -50,11 +51,11 @@ func testConfig() *config.Config {
 		InfluxDBPort:       influxPort,
 		DBName:             "metrics",
 		BatchMessages:      1,
-		BatchMaxMB:         10,
+		BatchMaxSize:       10 * datasize.MB,
 		BatchMaxSecs:       300,
 		Port:               influxPort,
 		Workers:            96,
-		NATSPendingMaxMB:   32,
+		NATSMaxPendingSize: 32 * datasize.MB,
 		ProbePort:          probePort,
 	}
 }
@@ -122,7 +123,7 @@ func TestBatchMBLimit(t *testing.T) {
 	conf := testConfig()
 	conf.Workers = 1
 	conf.BatchMessages = 9999
-	conf.BatchMaxMB = 1
+	conf.BatchMaxSize = 1 * datasize.MB
 	w := startWriter(t, conf)
 	defer w.Stop()
 

--- a/writer/writer_medium_test.go
+++ b/writer/writer_medium_test.go
@@ -52,7 +52,7 @@ func testConfig() *config.Config {
 		DBName:             "metrics",
 		BatchMessages:      1,
 		BatchMaxSize:       10 * datasize.MB,
-		BatchMaxSecs:       300,
+		BatchMaxAge:        config.Duration{5 * time.Minute},
 		Port:               influxPort,
 		Workers:            96,
 		NATSMaxPendingSize: 32 * datasize.MB,
@@ -160,12 +160,12 @@ func TestBatchTimeLimit(t *testing.T) {
 	conf := testConfig()
 	conf.Workers = 1
 	conf.BatchMessages = 9999
-	conf.BatchMaxSecs = 1
+	conf.BatchMaxAge = config.Duration{time.Second}
 	w := startWriter(t, conf)
 	defer w.Stop()
 
 	// Send one small message. It should still come through because of
-	// BatchMaxSecs.
+	// BatchMaxAge.
 	publish(t, nc, conf.NATSSubject[0], "foo")
 
 	influxd.AssertWrite(t, "foo")


### PR DESCRIPTION
This is a significant rationalisation of influx-spout's configuration and breaks backwards compatibliity. Highlights:

* bytes sizes are now represented internally using a specialised type and are parsed from strings which may have unit suffixes (e.g. `"200MB"`)
* The listener_batch_size option has been removed. The listener now uses the `batch_max_size` option for this (these options had the same purpose but were previously separate due to scaling issues).
* Time duration based values are now represented using a time.Duration and are parsed from user friendly strings (e.g. `"5m"` and `"30s"`) instead of being fixed in seconds.
* The `batch` option has been renamed to the more descriptive `batch_max_count`.

Summary of configuration fields renamed in this PR:

- batch_max_mb -> batch_max_size
- nats_pending_max_mb -> nats_max_pending_size
- read_buffer_bytes -> read_buffer_size
- batch_max_secs -> batch_max_age
- max_time_delta_secs -> max_time_delta
- write_timeout_secs -> write_timeout
- batch -> batch_max_count