### PR TITLE
Introduce new "tags" filter rule type

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,10 +296,24 @@ match = "cgroup"
 # Measurements matching the rule are forwarded to this subject.
 subject = "measurement.cgroup"
 
+[[rule]]
+# "tags" rules match measurement tags exactly.
+type = "tags"
+
+# Each item in "tags" specifies a tag key and value pair. All tags specified
+# must be present for the line to match the rule.
+tags = [
+  ["key1", "value1"],
+  ["key2", "value2"],
+]
+
+# As above.
+subject = "somewhere"
 
 [[rule]]
 # "regex" rules apply a regular expression to full measurement lines.
-# Note: regex rules are significantly slower than basic rules. Use with care.
+# Note: regex rules are significantly slower than basic and tags rules. Use
+# with care.
 type = "regex"
 
 # For regex rules, "match" specifies regular expression pattern to apply.
@@ -397,16 +411,19 @@ probe_port = 0
 # The writer will serve Go pprof requests at this port. Set to 0 (the default)
 # to disable pprof support.
 pprof_port = 0
+
+# Writers can optionally include filter rules. When filter rules are configured,
+# measurements which don't match a rule will be dropped by the writer instead
+# of being written to InfluxDB. Rule configuration is the same as for the
+# filter component, but the rule subject should be omitted.
+[[rule]]
+type = "basic"
+match = "cgroup"
 ```
 
 A writer will batch up messages until one of the limits defined by the
 `batch_max_count`, `batch_max_size` or `batch_max_age` options is
 reached.
-
-Writers can optionally include filter rules. When filter rules are configured
-measurements which don't match a rule will be dropped by the writer instead of
-being written to InfluxDB. Rule configuration is the same as for the filter
-component, but the rule subject should be omitted.
 
 ### Monitor
 

--- a/config/config.go
+++ b/config/config.go
@@ -60,9 +60,10 @@ type Config struct {
 
 // Rule contains the configuration for a single filter rule.
 type Rule struct {
-	Rtype   string `toml:"type"`
-	Match   string `toml:"match"`
-	Subject string `toml:"subject"`
+	Rtype   string     `toml:"type"`
+	Match   string     `toml:"match"`
+	Tags    [][]string `toml:"tags"`
+	Subject string     `toml:"subject"`
 }
 
 func newDefaultConfig() *Config {
@@ -130,11 +131,27 @@ func (c *Config) validateFilter() error {
 		if rule.Rtype == "" {
 			return errors.New(`rule missing "type"`)
 		}
-		if rule.Match == "" {
-			return errors.New(`rule missing "match"`)
-		}
 		if rule.Subject == "" {
 			return errors.New(`rule missing "subject"`)
+		}
+		if rule.Rtype != "tags" && rule.Match == "" {
+			return errors.New(`rule missing "match"`)
+		}
+		if rule.Rtype != "tags" && len(rule.Tags) > 0 {
+			return fmt.Errorf(`%s rule cannot use "tags"`, rule.Rtype)
+		}
+		if rule.Rtype == "tags" {
+			if rule.Match != "" {
+				return errors.New(`tags rule cannot use "match"`)
+			}
+			if len(rule.Tags) == 0 {
+				return errors.New(`tags rule missing "tags"`)
+			}
+			for _, tag := range rule.Tags {
+				if len(tag) != 2 {
+					return errors.New("each tags item must contain 2 values")
+				}
+			}
 		}
 	}
 	return nil

--- a/config/config_small_test.go
+++ b/config/config_small_test.go
@@ -182,23 +182,39 @@ match = "hello"
 subject = "hello-subject"
 
 [[rule]]
-type = "basic"
+type = "regex"
 match = "world"
 subject = "world-subject"
+
+[[rule]]
+type = "tags"
+tags = [
+   ["foo", "bar"],
+   ["aaa", "zzz"],
+]
+subject = "foo-subject"
 `
 	conf, err := parseConfig(rulesConfig)
 	require.NoError(t, err, "config should be parsed")
 
-	assert.Len(t, conf.Rule, 2)
+	assert.Len(t, conf.Rule, 3)
 	assert.Equal(t, conf.Rule[0], Rule{
 		Rtype:   "basic",
 		Match:   "hello",
 		Subject: "hello-subject",
 	})
 	assert.Equal(t, conf.Rule[1], Rule{
-		Rtype:   "basic",
+		Rtype:   "regex",
 		Match:   "world",
 		Subject: "world-subject",
+	})
+	assert.Equal(t, conf.Rule[2], Rule{
+		Rtype: "tags",
+		Tags: [][]string{
+			{"foo", "bar"},
+			{"aaa", "zzz"},
+		},
+		Subject: "foo-subject",
 	})
 }
 
@@ -381,6 +397,46 @@ type = "basic"
 match = "needle"
 `,
 		`rule missing "subject"`,
+	}, {
+		`
+mode = "filter"
+
+[[rule]]
+type = "basic"
+match = "something"
+subject = "out"
+tags = [["abc", "def"]]
+`,
+		`basic rule cannot use "tags"`,
+	}, {
+		`
+mode = "filter"
+
+[[rule]]
+type = "tags"
+subject = "out"
+match = "something"
+`,
+		`tags rule cannot use "match"`,
+	}, {
+		`
+mode = "filter"
+
+[[rule]]
+type = "tags"
+subject = "out"
+`,
+		`tags rule missing "tags"`,
+	}, {
+		`
+mode = "filter"
+
+[[rule]]
+type = "tags"
+tags = [["abc", "def", "zzz"]]
+subject = "out"
+`,
+		`each tags item must contain 2 values`,
 	}, {
 		`
 mode = "writer"


### PR DESCRIPTION
This allows matching against one or more exact tags on measurement
lines. The approach taken is much faster than using regexes to achieve
the same kinds of matches (80-1000% depending on number tags to match
and size of line). This approach is also much safer as matching is
independent of tag order and matches tag keys and values precisely.

This change features some nice improvements in how line parsing is
done in the filter.

Closes #90.