### PR TITLE
convert: ToInt now supports negative numbers

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -14,19 +14,28 @@
 
 package convert
 
-import "errors"
-
-const int64Max = (1 << 63) - 1
+import (
+	"errors"
+	"math"
+)
 
 // ToInt is a simpler, faster version of strconv.ParseInt().
 // Differences to ParseInt:
 // - input is []byte instead of a string (no type conversion required
 //   by caller)
 // - only supports base 10 input
-// - only handles positive values
 func ToInt(s []byte) (int64, error) {
-	if len(s) == 0 {
+	if len(s) < 1 {
 		return 0, errors.New("empty")
+	}
+
+	negative := false
+	if s[0] == '-' {
+		negative = true
+		s = s[1:]
+		if len(s) < 1 {
+			return 0, errors.New("too short")
+		}
 	}
 
 	var n uint64
@@ -39,7 +48,13 @@ func ToInt(s []byte) (int64, error) {
 		n = n*10 + uint64(c)
 	}
 
-	if n > int64Max {
+	if negative {
+		if n > -math.MinInt64 {
+			return 0, errors.New("overflow")
+		}
+		return -int64(n), nil
+	}
+	if n > math.MaxInt64 {
 		return 0, errors.New("overflow")
 	}
 	return int64(n), nil

--- a/convert/convert_small_test.go
+++ b/convert/convert_small_test.go
@@ -17,10 +17,10 @@
 package convert_test
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/jumptrading/influx-spout/convert"
 )
@@ -28,24 +28,32 @@ import (
 func TestToInt(t *testing.T) {
 	check := func(input string, expected int64) {
 		actual, err := convert.ToInt([]byte(input))
-		require.NoError(t, err)
+		assert.NoError(t, err, "ToInt(%q) returned error", input)
 		assert.Equal(t, expected, actual, "ToInt(%q)", input)
 	}
 
 	shouldFail := func(input string) {
 		_, err := convert.ToInt([]byte(input))
-		assert.Error(t, err)
+		assert.Error(t, err, "ToInt(%q)", input)
 	}
 
 	check("0", 0)
+	check("-0", 0)
 	check("1", 1)
+	check("-1", -1)
 	check("9", 9)
 	check("10", 10)
 	check("99", 99)
+	check("-99", -99)
 	check("101", 101)
-	check("9223372036854775807", (1<<63)-1) // max int64 value
+	check("-101", -101)
+	check("9223372036854775807", math.MaxInt64)
+	check("-9223372036854775808", math.MinInt64)
 
-	shouldFail("9223372036854775808") // max int64 value + 1
-	shouldFail("-1")                  // negatives not supported
+	shouldFail("")
 	shouldFail("x")
+	shouldFail("-")
+	shouldFail("+2")
+	shouldFail("9223372036854775808")  // max int64 value + 1
+	shouldFail("-9223372036854775809") // min int64 - 1
 }

--- a/influx/timestamps_small_test.go
+++ b/influx/timestamps_small_test.go
@@ -52,13 +52,13 @@ func TestExtractTimestamp(t *testing.T) {
 	check("weather,city=paris temp=60 "+tsStr, ts, 27)
 	check("weather,city=paris temp=60,humidity=100 "+tsStr, ts, 40)
 	check("weather,city=paris temp=60,humidity=100 "+tsStr+"\n", ts, 40)
+	check("weather temp=99 -"+tsStr, -ts, 16)
 
 	// Various invalid timestamps
 	noTimestamp("weather temp=99 " + tsStr + " ")       // trailing whitespace
 	noTimestamp("weather temp=99 xxxxx")                // not digits
 	noTimestamp("weather temp=99 15x07")                // embedded non-digit
 	noTimestamp("weather temp=99 00000000000000000001") // too long
-	noTimestamp("weather temp=99 -" + tsStr)            // negative
 	noTimestamp(tsStr)                                  // timestamp only
 }
 
@@ -88,13 +88,13 @@ func TestExtractNanos(t *testing.T) {
 	check("weather,city=paris temp=60 "+tsStr, ts, 27)
 	check("weather,city=paris temp=60,humidity=100 "+tsStr, ts, 40)
 	check("weather,city=paris temp=60,humidity=100 "+tsStr+"\n", ts, 40)
+	check("weather temp=99 -"+tsStr, -ts, 16)
 
 	// Various invalid timestamps
 	noTimestamp("weather temp=99 " + tsStr + " ")       // trailing whitespace
 	noTimestamp("weather temp=99 xxxxxxxxxxxxxxxxxxx")  // not digits
 	noTimestamp("weather temp=99 152076148x803180202")  // embedded non-digit
 	noTimestamp("weather temp=99 11520761485803180202") // too long
-	noTimestamp("weather temp=99 -" + tsStr)            // negative
 	noTimestamp(tsStr)                                  // timestamp only
 }
 


### PR DESCRIPTION
This is required to support the upcoming measurement downsampling feature (#100)