### PR TITLE
Implement tag ordering

### DIFF
--- a/cmd/influx-spout/e2e_large_test.go
+++ b/cmd/influx-spout/e2e_large_test.go
@@ -178,7 +178,7 @@ $`[1:])
 	t.Fatalf("Failed to see expected metrics. Last saw:\n%s", lines)
 }
 
-const cpuLine = "cpu,env=prod,cls=server user=13.33,usage_system=0.16,usage_idle=86.53"
+const cpuLine = "cpu,cls=server,env=prod user=13.33,usage_system=0.16,usage_idle=86.53"
 
 func makeTestLines() *bytes.Buffer {
 	now := time.Now().UnixNano()

--- a/filter/rules.go
+++ b/filter/rules.go
@@ -40,8 +40,7 @@ func CreateBasicRule(measurement string, subject string) Rule {
 
 	return Rule{
 		match: func(line *parsedLine) bool {
-			// TODO: cached hashed measurement
-			return hh == hashMeasurement(line.Measurement)
+			return hh == line.HashedMeasurement()
 		},
 		subject: subject,
 	}
@@ -170,11 +169,14 @@ func newParsedLine(escaped []byte) (*parsedLine, error) {
 }
 
 type parsedLine struct {
-	Original    []byte
-	unescaped   []byte
-	Measurement []byte
-	Tags        influx.TagSet
-	Remainder   []byte
+	Original  []byte
+	unescaped []byte
+
+	Measurement       []byte
+	hashedMeasurement *uint32
+
+	Tags      influx.TagSet
+	Remainder []byte
 }
 
 func (pl *parsedLine) Unescaped() []byte {
@@ -183,4 +185,12 @@ func (pl *parsedLine) Unescaped() []byte {
 		pl.unescaped = influx.Unescape(pl.Original)
 	}
 	return pl.unescaped
+}
+
+func (pl *parsedLine) HashedMeasurement() uint32 {
+	if pl.hashedMeasurement == nil {
+		h := hashMeasurement(pl.Measurement)
+		pl.hashedMeasurement = &h
+	}
+	return *pl.hashedMeasurement
 }

--- a/filter/rules.go
+++ b/filter/rules.go
@@ -21,6 +21,7 @@ import (
 	"regexp"
 
 	"github.com/jumptrading/influx-spout/config"
+	"github.com/jumptrading/influx-spout/influx"
 )
 
 // Rule encapsulates a matching function and the NATS topic to
@@ -169,7 +170,7 @@ func (rs *RuleSet) Lookup(escaped []byte) int {
 	for i, rule := range rs.rules {
 		if rule.needsUnescaped {
 			if unescaped == nil {
-				unescaped = influxUnescape(escaped)
+				unescaped = influx.Unescape(escaped)
 			}
 			line = unescaped
 		} else {
@@ -238,7 +239,7 @@ func parseNext(s []byte, until []byte) ([]byte, []byte) {
 		i++
 		if i >= len(s) {
 			if escaped {
-				s = influxUnescape(s)
+				s = influx.Unescape(s)
 			}
 			return s, nil
 		}
@@ -253,7 +254,7 @@ func parseNext(s []byte, until []byte) ([]byte, []byte) {
 			if s[i] == c {
 				out := s[:i]
 				if escaped {
-					out = influxUnescape(out)
+					out = influx.Unescape(out)
 				}
 				return out, s[i:]
 			}

--- a/filter/rules.go
+++ b/filter/rules.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"regexp"
+	"sort"
 
 	"github.com/jumptrading/influx-spout/config"
 	"github.com/jumptrading/influx-spout/influx"
@@ -144,9 +145,15 @@ func (rs *RuleSet) Subjects() []string {
 func (rs *RuleSet) Lookup(escaped []byte) int {
 	line, err := newParsedLine(escaped)
 	if err != nil {
-		// TODO: counter for malformed lines
 		return -1
 	}
+	return rs.LookupParsed(line)
+}
+
+// LookupParsed takes a parsedLine and checks for a matching rule in
+// the RuleSet. The index of the matching rule is returned. Returns -1
+// if there was no match.
+func (rs *RuleSet) LookupParsed(line *parsedLine) int {
 	for i, rule := range rs.rules {
 		if rule.match(line) {
 			return i
@@ -160,16 +167,23 @@ func newParsedLine(escaped []byte) (*parsedLine, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return &parsedLine{
-		Original:    escaped,
+		Escaped:     escaped,
 		Measurement: measurement,
 		Tags:        tags,
 		Remainder:   remainder,
 	}, nil
 }
 
+// parsedLine caches artefacts related to a single measurement line
+// being checked by the filtering. Caching avoids unnecessarily
+// recalculating values which are used by multiple rules. Cached
+// values are calculated lazily on first use.
+//
+// parseLine also handles tag ordering (see SortTags).
 type parsedLine struct {
-	Original  []byte
+	Escaped   []byte
 	unescaped []byte
 
 	Measurement       []byte
@@ -182,7 +196,7 @@ type parsedLine struct {
 func (pl *parsedLine) Unescaped() []byte {
 	// Cached unescaped version if it hasn't been generated yet.
 	if pl.unescaped == nil {
-		pl.unescaped = influx.Unescape(pl.Original)
+		pl.unescaped = influx.Unescape(pl.Escaped)
 	}
 	return pl.unescaped
 }
@@ -193,4 +207,38 @@ func (pl *parsedLine) HashedMeasurement() uint32 {
 		pl.hashedMeasurement = &h
 	}
 	return *pl.hashedMeasurement
+}
+
+func (pl *parsedLine) SortTags() {
+	if sort.IsSorted(pl.Tags) {
+		// Tags are already sorted so nothing to do.
+		return
+	}
+
+	sort.Sort(pl.Tags)
+
+	// Replace Escaped with sorted tags version.
+
+	var newHdr []byte
+	newHdr = append(newHdr, influx.EscapeMeasurement(pl.Measurement)...)
+	newHdr = append(newHdr, ',')
+	newHdr = append(newHdr, pl.Tags.Bytes()...)
+
+	if len(pl.Remainder) == 0 {
+		// Nothing left so "newHdr" is exactly what needs to be returned.
+		pl.Escaped = newHdr
+		return
+	}
+
+	if len(newHdr)+len(pl.Remainder)+1 == len(pl.Escaped) {
+		// Length hasn't changed so reuse memory used by original,
+		// overwriting the measurement name and tags part.
+		copy(pl.Escaped, newHdr)
+		return
+	}
+
+	// Length as changed (original escaped differently?)
+	newHdr = append(newHdr, ' ')
+	newHdr = append(newHdr, pl.Remainder...)
+	pl.Escaped = newHdr
 }

--- a/filter/rules.go
+++ b/filter/rules.go
@@ -15,7 +15,6 @@
 package filter
 
 import (
-	"bytes"
 	"fmt"
 	"hash/fnv"
 	"regexp"
@@ -28,12 +27,7 @@ import (
 // send lines to if the rule matches.
 type Rule struct {
 	// Function used to check if the rule matches
-	match func([]byte) bool
-
-	// needsUnescaped is true if the match function needs the
-	// unescaped version of the line. The raw version of the line is
-	// passed otherwise.
-	needsUnescaped bool
+	match func(*parsedLine) bool
 
 	// if the rule matches, the measurement is sent to this NATS subject
 	subject string
@@ -45,9 +39,9 @@ func CreateBasicRule(measurement string, subject string) Rule {
 	hh := hashMeasurement([]byte(measurement))
 
 	return Rule{
-		match: func(line []byte) bool {
-			name, _ := influx.Token(line, []byte(", "))
-			return hh == hashMeasurement(name)
+		match: func(line *parsedLine) bool {
+			// TODO: cached hashed measurement
+			return hh == hashMeasurement(line.Measurement)
 		},
 		subject: subject,
 	}
@@ -64,11 +58,10 @@ func hashMeasurement(measurement []byte) uint32 {
 func CreateRegexRule(regexString, subject string) Rule {
 	reg := regexp.MustCompile(regexString)
 	return Rule{
-		match: func(line []byte) bool {
-			return reg.Match(line)
+		match: func(line *parsedLine) bool {
+			return reg.Match(line.Unescaped())
 		},
-		needsUnescaped: true,
-		subject:        subject,
+		subject: subject,
 	}
 }
 
@@ -77,34 +70,19 @@ func CreateRegexRule(regexString, subject string) Rule {
 func CreateNegativeRegexRule(regexString, subject string) Rule {
 	reg := regexp.MustCompile(regexString)
 	return Rule{
-		match: func(line []byte) bool {
-			return !reg.Match(line)
+		match: func(line *parsedLine) bool {
+			return !reg.Match(line.Unescaped())
 		},
-		needsUnescaped: true,
-		subject:        subject,
+		subject: subject,
 	}
-}
-
-// NewTag creates a new Tag instance from key & value strings.
-func NewTag(key, value string) Tag {
-	return Tag{
-		Key:   []byte(key),
-		Value: []byte(value),
-	}
-}
-
-// Tag represents a key/value pair (both bytes).
-type Tag struct {
-	Key   []byte
-	Value []byte
 }
 
 // CreateTagRule creates a rule that efficiently matches one or more
 // measurement tags.
-func CreateTagRule(tags []Tag, subject string) Rule {
+func CreateTagRule(tags influx.TagSet, subject string) Rule {
 	return Rule{
-		match: func(line []byte) bool {
-			return hasAllTags(line, tags)
+		match: func(line *parsedLine) bool {
+			return tags.SubsetOf(line.Tags)
 		},
 		subject: subject,
 	}
@@ -120,10 +98,10 @@ func RuleSetFromConfig(conf *config.Config) (*RuleSet, error) {
 			rs.Append(CreateBasicRule(r.Match, r.Subject))
 		case "tags":
 			// Convert tags as [][]string from config into []Tag.
-			tags := make([]Tag, 0, len(r.Tags))
+			tags := make(influx.TagSet, 0, len(r.Tags))
 			for _, raw := range r.Tags {
 				// This is safe because Config is validated.
-				tags = append(tags, NewTag(raw[0], raw[1]))
+				tags = append(tags, influx.NewTag(raw[0], raw[1]))
 			}
 			rs.Append(CreateTagRule(tags, r.Subject))
 		case "regex":
@@ -165,17 +143,12 @@ func (rs *RuleSet) Subjects() []string {
 // Lookup takes a raw line and returns the index of the rule in the
 // RuleSet that matches it. Returns -1 if there was no match.
 func (rs *RuleSet) Lookup(escaped []byte) int {
-	var unescaped []byte
-	var line []byte
+	line, err := newParsedLine(escaped)
+	if err != nil {
+		// TODO: counter for malformed lines
+		return -1
+	}
 	for i, rule := range rs.rules {
-		if rule.needsUnescaped {
-			if unescaped == nil {
-				unescaped = influx.Unescape(escaped)
-			}
-			line = unescaped
-		} else {
-			line = escaped
-		}
 		if rule.match(line) {
 			return i
 		}
@@ -183,39 +156,31 @@ func (rs *RuleSet) Lookup(escaped []byte) int {
 	return -1
 }
 
-func hasAllTags(line []byte, tags []Tag) bool {
-	_, line = influx.Token(line, []byte(", "))
-	if len(line) == 0 {
-		return false
+func newParsedLine(escaped []byte) (*parsedLine, error) {
+	measurement, tags, remainder, err := influx.ParseTags(escaped)
+	if err != nil {
+		return nil, err
 	}
+	return &parsedLine{
+		Original:    escaped,
+		Measurement: measurement,
+		Tags:        tags,
+		Remainder:   remainder,
+	}, nil
+}
 
-	numTags := len(tags)
-	found := make([]bool, numTags)
-	foundCount := 0
-	var key, value []byte
-	for {
-		if len(line) == 0 || line[0] == ' ' {
-			return false
-		}
+type parsedLine struct {
+	Original    []byte
+	unescaped   []byte
+	Measurement []byte
+	Tags        influx.TagSet
+	Remainder   []byte
+}
 
-		key, line = influx.Token(line[1:], []byte("="))
-		if len(line) == 0 {
-			return false
-		}
-
-		value, line = influx.Token(line[1:], []byte(", "))
-		if len(line) == 0 {
-			return false
-		}
-
-		for t := 0; t < numTags; t++ {
-			if !found[t] && bytes.Equal(key, tags[t].Key) && bytes.Equal(value, tags[t].Value) {
-				found[t] = true
-				foundCount++
-				if foundCount == numTags {
-					return true
-				}
-			}
-		}
+func (pl *parsedLine) Unescaped() []byte {
+	// Cached unescaped version if it hasn't been generated yet.
+	if pl.unescaped == nil {
+		pl.unescaped = influx.Unescape(pl.Original)
 	}
+	return pl.unescaped
 }

--- a/filter/rules_small_test.go
+++ b/filter/rules_small_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/jumptrading/influx-spout/config"
+	"github.com/jumptrading/influx-spout/influx"
 	"github.com/jumptrading/influx-spout/spouttest"
 	"github.com/jumptrading/influx-spout/stats"
 )
@@ -109,7 +110,7 @@ func TestNegativeRegexRuleUnescapes(t *testing.T) {
 
 func TestTagRuleSingle(t *testing.T) {
 	rs := new(RuleSet)
-	tags := []Tag{NewTag("key", "value")}
+	tags := influx.TagSet{influx.NewTag("key", "value")}
 	rs.Append(CreateTagRule(tags, ""))
 
 	assert.Equal(t, 0, rs.Lookup([]byte(`foo,key=value x=22`)))
@@ -125,9 +126,9 @@ func TestTagRuleSingle(t *testing.T) {
 
 func TestTagRuleMulti(t *testing.T) {
 	rs := new(RuleSet)
-	tags := []Tag{
-		NewTag("host", "db01"),
-		NewTag("dc", "nyc"),
+	tags := influx.TagSet{
+		influx.NewTag("host", "db01"),
+		influx.NewTag("dc", "nyc"),
 	}
 	rs.Append(CreateTagRule(tags, ""))
 
@@ -144,8 +145,8 @@ func TestTagRuleMulti(t *testing.T) {
 
 func TestTagRuleEscaping(t *testing.T) {
 	rs := new(RuleSet)
-	rs.Append(CreateTagRule([]Tag{NewTag("ke y", "val,ue")}, ""))
-	rs.Append(CreateTagRule([]Tag{NewTag("k=k", "v=v")}, ""))
+	rs.Append(CreateTagRule(influx.TagSet{influx.NewTag("ke y", "val,ue")}, ""))
+	rs.Append(CreateTagRule(influx.TagSet{influx.NewTag("k=k", "v=v")}, ""))
 
 	assert.Equal(t, 0, rs.Lookup([]byte(`foo,ke\ y=val\,ue x=22`)))
 	assert.Equal(t, 0, rs.Lookup([]byte(`foo,ke\ y=val\,ue,host=gopher01 x=22`)))
@@ -240,7 +241,7 @@ func BenchmarkLineLookupTag(b *testing.B) {
 	defer spouttest.RestoreLogs()
 
 	rs := new(RuleSet)
-	rs.Append(CreateTagRule([]Tag{NewTag("foo", "bar")}, ""))
+	rs.Append(CreateTagRule(influx.TagSet{influx.NewTag("foo", "bar")}, ""))
 	line := []byte("hello,aaa=bbb,foo=bar,cheese=stilton world=42")
 
 	b.ResetTimer()
@@ -254,9 +255,9 @@ func BenchmarkLineLookupTagMulti(b *testing.B) {
 	defer spouttest.RestoreLogs()
 
 	rs := new(RuleSet)
-	rs.Append(CreateTagRule([]Tag{
-		NewTag("foo", "bar"),
-		NewTag("cheese", "stilton"),
+	rs.Append(CreateTagRule(influx.TagSet{
+		influx.NewTag("foo", "bar"),
+		influx.NewTag("cheese", "stilton"),
 	}, ""))
 	line := []byte("hello,aaa=bbb,foo=bar,cheese=stilton world=42")
 

--- a/filter/rules_small_test.go
+++ b/filter/rules_small_test.go
@@ -191,33 +191,6 @@ func TestRuleSet(t *testing.T) {
 	assert.Equal(t, -1, rs.Lookup([]byte("blah,foo=negreg-match")))
 }
 
-func TestParseNext(t *testing.T) {
-	check := func(input, until, exp, expRemainder string) {
-		actual, actualRemainder := parseNext([]byte(input), []byte(until))
-		assert.Equal(t, exp, string(actual), "parseNext(%q, %q)", input, until)
-		assert.Equal(t, expRemainder, string(actualRemainder), "parseNext(%q, %q) (remainder)", input, until)
-	}
-
-	check("", " ", "", "")
-	check(`a`, " ", `a`, "")
-	check("日", " ", "日", "")
-	check(`hello`, " ", `hello`, "")
-	check("日本語", " ", "日本語", "")
-	check(" ", ", ", "", " ")
-	check(",", ", ", "", ",")
-	check(`h world`, ", ", `h`, " world")
-	check(`h,world`, ", ", `h`, ",world")
-	check(`hello world`, ", ", `hello`, ` world`)
-	check(`hello,world`, ", ", `hello`, `,world`)
-	check(`hello\ world more`, ", ", `hello world`, ` more`)
-	check(`hello\,world,more`, ", ", `hello,world`, `,more`)
-	check(`hello\ 日本語 more`, ", ", `hello 日本語`, ` more`)
-	check(`hello\,日本語,more`, ", ", `hello,日本語`, `,more`)
-	check(`\ `, " ", " ", "")
-	check(`\`, " ", `\`, "")
-	check(`hello\`, " ", `hello\`, "")
-}
-
 var result int
 
 func BenchmarkLineLookup(b *testing.B) {

--- a/influx/escape.go
+++ b/influx/escape.go
@@ -1,0 +1,82 @@
+// Copyright 2018 Jump Trading
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package influx
+
+import (
+	"bytes"
+)
+
+// EscapeTagPart escapes the characters that need to be escaped in a
+// tag key or tag value.
+func EscapeTagPart(in []byte) []byte {
+	return Escape(in, []byte(`,= `))
+}
+
+// EscapeMeasurement escapes the characters that need to escaped in a
+// measurement name.
+func EscapeMeasurement(in []byte) []byte {
+	return Escape(in, []byte(`, `))
+}
+
+// Escape returns IN with any bytes in CHARS backslash escaped.
+func Escape(in []byte, chars []byte) []byte {
+	if len(chars) == 0 {
+		// Short circuit, no characters to escape.
+		return in
+	}
+	toEscapeCount := countBytes(in, chars)
+	if toEscapeCount == 0 {
+		// Short circuit, no escaping needed.
+		return in
+	}
+
+	// Allocate exactly the right size to avoid further allocations
+	// and copies.
+	out := make([]byte, 0, len(in)+toEscapeCount)
+
+	for _, b := range in {
+		if containsByte(chars, b) {
+			out = append(out, '\\')
+		}
+		out = append(out, b)
+	}
+	return out
+}
+
+// countBytes returns the number of times of any of CHARS appears in
+// IN.
+func countBytes(in []byte, chars []byte) int {
+	count := 0
+	for _, c := range in {
+		if containsByte(chars, c) {
+			count++
+		}
+	}
+	return count
+}
+
+func containsAny(in []byte, chars []byte) bool {
+	for _, c := range chars {
+		if containsByte(in, c) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsByte(in []byte, b byte) bool {
+	// IndexByte is fast (implemented in asm)
+	return bytes.IndexByte(in, b) >= 0
+}

--- a/influx/escape_small_test.go
+++ b/influx/escape_small_test.go
@@ -1,0 +1,58 @@
+// Copyright 2018 Jump Trading
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build small
+
+package influx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEscape(t *testing.T) {
+	check := func(input, chars, expected string) {
+		assert.Equal(
+			t,
+			expected,
+			string(Escape([]byte(input), []byte(chars))),
+			"Escape(%q, %q)", input, chars,
+		)
+	}
+
+	// Basic cases with no escapes
+	check(``, `,`, ``)
+	check("h", `,`, "h")
+	check("日", `,`, "日")
+	check("hello", `,`, "hello")
+	check("日本語", `,`, "日本語")
+
+	// Single characters
+	check(` `, ` ,"=`, `\ `)
+	check(`,`, ` ,"=`, `\,`)
+	check(`"`, ` ,"=`, `\"`)
+	check(`=`, ` ,"=`, `\=`)
+
+	// Only escapes the listed characters
+	check(`=`, `,`, `=`)
+
+	// More complex
+	check(`,x`, ` ,"=`, `\,x`)
+	check(`x,`, ` ,"=`, `x\,`)
+	check(`"x"`, ` ,"=`, `\"x\"`)
+	check(` ,"=`, ` ,"=`, `\ \,\"\=`)
+	check(`"stuff, =things"`, ` ,"=`, `\"stuff\,\ \=things\"`)
+	check(`,日"本 語=`, ` ,"=`, `\,日\"本\ 語\=`)
+}

--- a/influx/tags.go
+++ b/influx/tags.go
@@ -1,0 +1,81 @@
+// Copyright 2018 Jump Trading
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package influx
+
+import (
+	"bytes"
+	"errors"
+)
+
+// NewTag creates a new Tag instance from key & value strings.
+func NewTag(key, value string) Tag {
+	return Tag{
+		Key:   []byte(key),
+		Value: []byte(value),
+	}
+}
+
+// Tag represents a key/value pair (both bytes).
+type Tag struct {
+	Key   []byte
+	Value []byte
+}
+
+// TagSet hold a number of Tag pairs. It implements sort.Interface.
+type TagSet []Tag
+
+func (t TagSet) Len() int           { return len(t) }
+func (t TagSet) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
+func (t TagSet) Less(i, j int) bool { return bytes.Compare(t[i].Key, t[j].Key) < 0 }
+
+// ParseTags extracts the measurement name and tagset out of a
+// line. The measurement name, tag key and tag values are
+// unescaped. The remainder of the line (i.e. fields and timestamp) is
+// also returned unchanged. Errors are returned if incorrectly
+// formatted tags are present in the line.
+func ParseTags(line []byte) ([]byte, TagSet, []byte, error) {
+	measurement, line := Token(line, []byte(", "))
+
+	if len(line) == 0 {
+		// Measurement without anything else.
+		return measurement, nil, nil, nil
+	}
+
+	var tags TagSet
+	var key, value []byte
+	for {
+		if len(line) == 0 {
+			return measurement, tags, nil, nil
+		}
+		if line[0] == ' ' {
+			return measurement, tags, line[1:], nil
+		}
+
+		key, line = Token(line[1:], []byte("= ,"))
+		if len(line) == 0 || line[0] != '=' {
+			return nil, nil, nil, errors.New("invalid tag")
+		}
+
+		value, line = Token(line[1:], []byte(", "))
+		if len(value) == 0 {
+			return nil, nil, nil, errors.New("invalid tag")
+		}
+
+		tags = append(tags, Tag{
+			Key:   key,
+			Value: value,
+		})
+	}
+}

--- a/influx/tags.go
+++ b/influx/tags.go
@@ -40,6 +40,29 @@ func (t TagSet) Len() int           { return len(t) }
 func (t TagSet) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
 func (t TagSet) Less(i, j int) bool { return bytes.Compare(t[i].Key, t[j].Key) < 0 }
 
+// SubsetOf returns true if T is a subset of OTHER.
+func (t TagSet) SubsetOf(other TagSet) bool {
+	if len(t) == 0 {
+		return true
+	}
+
+	numTags := len(t)
+	found := make([]bool, numTags)
+	foundCount := 0
+	for _, otherTag := range other {
+		for i, tag := range t {
+			if !found[i] && bytes.Equal(tag.Key, otherTag.Key) && bytes.Equal(tag.Value, otherTag.Value) {
+				found[i] = true
+				foundCount++
+				if foundCount == numTags {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
 // ParseTags extracts the measurement name and tagset out of a
 // line. The measurement name, tag key and tag values are
 // unescaped. The remainder of the line (i.e. fields and timestamp) is

--- a/influx/tags_small_test.go
+++ b/influx/tags_small_test.go
@@ -1,0 +1,109 @@
+// Copyright 2018 Jump Trading
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build small
+
+package influx
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseTags(t *testing.T) {
+	check := func(line string, em string, et TagSet, er string) {
+		am, at, ar, err := ParseTags([]byte(line))
+		assert.NoError(t, err)
+		assert.Equal(t, em, string(am), "wrong measurement, ParseTags(%q)", line)
+		assert.Equal(t, et, at, "wrong tags, ParseTags(%q)", line)
+		assert.Equal(t, er, string(ar), "wrong remainder, ParseTags(%q)", line)
+	}
+	checkError := func(line string, errMsg string) {
+		_, _, _, err := ParseTags([]byte(line))
+		assert.EqualError(t, err, errMsg)
+	}
+
+	check(``, "", nil, "")
+
+	// Just a measurement (unlikely)
+	check(`foo`, "foo", nil, "")
+
+	//No tags
+	check(`foo x=22`, "foo", nil, "x=22")
+	check(`foo x=22 y=true`, "foo", nil, "x=22 y=true")
+
+	// Single tag
+	check(`foo,host=s1 x=22`,
+		"foo",
+		TagSet{NewTag("host", "s1")},
+		"x=22",
+	)
+
+	// Multiple tags
+	check(`foo,host=s1,dc=nyc abc=22i xyz=3.141`,
+		"foo",
+		TagSet{
+			NewTag("host", "s1"),
+			NewTag("dc", "nyc"),
+		},
+		"abc=22i xyz=3.141",
+	)
+
+	// Tags without fields (unlikely)
+	check(`foo,host=s1,dc=nyc`,
+		"foo",
+		TagSet{
+			NewTag("host", "s1"),
+			NewTag("dc", "nyc"),
+		},
+		"",
+	)
+
+	// Escaping horror.
+	check(`fo\,o,h\=ost=s\,1,\,dc=\ nyc abc=22i xyz=3.141`,
+		"fo,o",
+		TagSet{
+			NewTag("h=ost", "s,1"),
+			NewTag(",dc", " nyc"),
+		},
+		"abc=22i xyz=3.141",
+	)
+
+	checkError(`foo,dc`, "invalid tag")
+	checkError(`foo,dc x=22`, "invalid tag")
+	checkError(`foo,dc,host=s1 x=22`, "invalid tag")
+	checkError(`foo,host=s1,dc x=22`, "invalid tag")
+	checkError(`foo,dc=`, "invalid tag")
+}
+
+func TestTagSetSorting(t *testing.T) {
+	tags := TagSet{
+		NewTag("foo", "0"),
+		NewTag("zeal", "2"),
+		NewTag("longer", "1"),
+		NewTag("bar", "3"),
+	}
+
+	sort.Sort(tags)
+
+	expected := TagSet{
+		NewTag("bar", "3"),
+		NewTag("foo", "0"),
+		NewTag("longer", "1"),
+		NewTag("zeal", "2"),
+	}
+	assert.Equal(t, expected, tags)
+}

--- a/influx/tags_small_test.go
+++ b/influx/tags_small_test.go
@@ -107,3 +107,44 @@ func TestTagSetSorting(t *testing.T) {
 	}
 	assert.Equal(t, expected, tags)
 }
+
+func TestSubsetOf(t *testing.T) {
+	tags := TagSet{
+		NewTag("foo", "0"),
+		NewTag("bar", "1"),
+		NewTag("sne", "2"),
+	}
+
+	// Equal sets.
+	assert.True(t, tags.SubsetOf(TagSet{
+		NewTag("sne", "2"),
+		NewTag("bar", "1"),
+		NewTag("foo", "0"),
+	}))
+
+	// Subset with extras.
+	assert.True(t, tags.SubsetOf(TagSet{
+		NewTag("sne", "2"),
+		NewTag("a", "3"),
+		NewTag("bar", "1"),
+		NewTag("foo", "0"),
+		NewTag("zzzzz", "4"),
+	}))
+
+	// Partial match (not sufficient).
+	assert.False(t, tags.SubsetOf(TagSet{
+		NewTag("sne", "2"),
+		NewTag("foo", "0"),
+	}))
+
+	// No overlap.
+	assert.False(t, tags.SubsetOf(TagSet{
+		NewTag("q", "0"),
+	}))
+
+	// Empty.
+	assert.False(t, tags.SubsetOf(nil))
+
+	// Empty source is always a subset of anything else.
+	assert.True(t, TagSet{}.SubsetOf(TagSet{NewTag("foo", "bar")}))
+}

--- a/influx/tags_small_test.go
+++ b/influx/tags_small_test.go
@@ -148,3 +148,36 @@ func TestSubsetOf(t *testing.T) {
 	// Empty source is always a subset of anything else.
 	assert.True(t, TagSet{}.SubsetOf(TagSet{NewTag("foo", "bar")}))
 }
+
+func TestBytes(t *testing.T) {
+	check := func(input TagSet, expected string) {
+		actual := input.Bytes()
+		assert.Equal(t, expected, string(actual), "input: %v", input)
+	}
+
+	// One tag.
+	check(TagSet{NewTag("foo", "bar")}, "foo=bar")
+
+	// Multiple tags.
+	check(
+		TagSet{
+			NewTag("foo", "0"),
+			NewTag("bar", "1"),
+			NewTag("sne", "2"),
+		},
+		"foo=0,bar=1,sne=2",
+	)
+
+	// Escaping.
+	check(
+		TagSet{
+			NewTag("foo=bar", "0"),
+			NewTag("ba,r", "1"),
+			NewTag("host", "a server"),
+		},
+		`foo\=bar=0,ba\,r=1,host=a\ server`,
+	)
+
+	// Empty.
+	check(TagSet{}, "")
+}

--- a/influx/token.go
+++ b/influx/token.go
@@ -1,0 +1,57 @@
+// Copyright 2018 Jump Trading
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package influx
+
+// Token takes an escaped line protocol line and returns the
+// unescaped characters leading up to until. It also returns the
+// escaped remainder of line.
+func Token(s []byte, until []byte) ([]byte, []byte) {
+	if len(s) == 1 {
+		for _, c := range until {
+			if s[0] == c {
+				return nil, s
+			}
+		}
+		return s, nil
+	}
+
+	escaped := false
+	i := 0
+	for {
+		i++
+		if i >= len(s) {
+			if escaped {
+				s = Unescape(s)
+			}
+			return s, nil
+		}
+
+		if s[i-1] == '\\' {
+			// Skip character (it's escaped).
+			escaped = true
+			continue
+		}
+
+		for _, c := range until {
+			if s[i] == c {
+				out := s[:i]
+				if escaped {
+					out = Unescape(out)
+				}
+				return out, s[i:]
+			}
+		}
+	}
+}

--- a/influx/token_small_test.go
+++ b/influx/token_small_test.go
@@ -1,0 +1,50 @@
+// Copyright 2018 Jump Trading
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build small
+
+package influx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToken(t *testing.T) {
+	check := func(input, until, exp, expRemainder string) {
+		actual, actualRemainder := Token([]byte(input), []byte(until))
+		assert.Equal(t, exp, string(actual), "Token(%q, %q)", input, until)
+		assert.Equal(t, expRemainder, string(actualRemainder), "Token(%q, %q) (remainder)", input, until)
+	}
+
+	check("", " ", "", "")
+	check(`a`, " ", `a`, "")
+	check("日", " ", "日", "")
+	check(`hello`, " ", `hello`, "")
+	check("日本語", " ", "日本語", "")
+	check(" ", ", ", "", " ")
+	check(",", ", ", "", ",")
+	check(`h world`, ", ", `h`, " world")
+	check(`h,world`, ", ", `h`, ",world")
+	check(`hello world`, ", ", `hello`, ` world`)
+	check(`hello,world`, ", ", `hello`, `,world`)
+	check(`hello\ world more`, ", ", `hello world`, ` more`)
+	check(`hello\,world,more`, ", ", `hello,world`, `,more`)
+	check(`hello\ 日本語 more`, ", ", `hello 日本語`, ` more`)
+	check(`hello\,日本語,more`, ", ", `hello,日本語`, `,more`)
+	check(`\ `, " ", " ", "")
+	check(`\`, " ", `\`, "")
+	check(`hello\`, " ", `hello\`, "")
+}

--- a/influx/unescape.go
+++ b/influx/unescape.go
@@ -1,15 +1,29 @@
-package filter
+// Copyright 2018 Jump Trading
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package influx
 
 import "bytes"
 
-// influxUnescape returns a new slice containing the unescaped version
-// of in.
+// Unescape returns a new slice containing the unescaped version of
+// in.
 //
 // This is the same as Unescape() from
 // github.com/influxdata/influxdb/pkg/escape.
 // It's copied here because it's not worth vendoring all of influxdb
 // just for this.
-func influxUnescape(in []byte) []byte {
+func Unescape(in []byte) []byte {
 	if bytes.IndexByte(in, '\\') == -1 {
 		return in
 	}
@@ -47,7 +61,7 @@ func influxUnescape(in []byte) []byte {
 			}
 		}
 		out = append(out, in[i])
-		i += 1
+		i++
 	}
 	return out
 }

--- a/influx/unescape_small_test.go
+++ b/influx/unescape_small_test.go
@@ -14,7 +14,7 @@
 
 // +build small
 
-package filter
+package influx
 
 import (
 	"testing"
@@ -24,8 +24,8 @@ import (
 
 func TestUnescape(t *testing.T) {
 	check := func(input, expected string) {
-		assert.Equal(t, expected, string(influxUnescape([]byte(input))),
-			"influxUnescape(%q)", input)
+		assert.Equal(t, expected, string(Unescape([]byte(input))),
+			"Unescape(%q)", input)
 	}
 
 	// Basic cases with no escapes


### PR DESCRIPTION
The filter now orders tag keys in all measurement lines passing through it (if required). This is required to support the upcoming downsampler feature (#100) and also helps InfluxDB efficiency.

Even though unnecessary computation, memory allocations and memory copies have been avoided where possible this has a negative impact on filter performance. According to perfcheck, the impact is visible but not enough to trigger a performance regression failure.

Extensive refactoring of the filter's line protocol parsing routines were made to support this change. Most of this functionality now resides in the `influx` package. All this is required for the upcoming downsampler feature.
