### PR TITLE
Set up automatic releases using Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: go
 
 go:
-  - 1.9.x
-  - "1.10"
-  - master  # find out if a upcoming change in Go is going to break us
+  - "1.10.4"
+  - "1.11"
+  - "master"  # find out if an upcoming change in Go is going to break us
 
 matrix:
   # We only want to fail the build based on stable versions of Go
@@ -25,3 +25,14 @@ env:
 notifications:
   slack:
     secure: Py9Z8gyzsr63Wx8+GZNluL18Npf1y08K4IqtODK7jb9bRddyrsEwjFrqCE8KGNfgbYc1h9UAE2MXEbX2vtF3nTrBHUzo8m15c9bKNlc5SJQO40B4+fu/xfzUn+XdDCaZyoaMBSUOrIJwTfFrPPWzfAa7g13xIXMk7Pa/bKAlkj+gFKhvHCf2JCf3sUSaZ+2/A4py9S5ljfAMYhk48XTKqODAZGnpRkgPnKRYvIBKrWGXhS8V++UHcR19Dng1ND+3y/t5mtjZuvSSm5e1EN0kjNVhhsCmZPBjeQUg17YbuzCh7qVCxI5clseAlaAx3MdImhiSCo44rgJ8oYpSR9I2MwN9wYL9h0aZ/V1vEUPZ9vyRRVe09T1MGsKMMrcSMflplV/vEk/v8eo2PC+tU+NfTyJd6dQ0eMF5SjOrUL2mOp0vxS6fGc+D8y1Lni/rrm9huGKPIKarzqBpye22npBm2OxYBgl9gZoGRzyZtyyTYBxp2PgcirfEbcM+UPoFC2cgRwfV5TacYaJfU6Jel+lmCyLbPzE/0ZXeQ/xNH4sWVhuGjYJj4t+cHNxhk4HDlza6eOXeh7feO8tivBcwO8+JWhNt0zzNWW+Nvu9XcFMtVhjaIwQh7A5w0AVtUs17dnbDcURvDSBjrh9WELFxE9gLB8uF52VQO6/FpnaQ6EWsIFg=
+
+# Create release tarball and publish to Github using GoReleaser.
+# Releases are only built with a specific Go version and only if a tag
+# is set.
+deploy:
+- provider: script
+  skip_cleanup: true
+  script: curl -sL https://git.io/goreleaser | bash
+  on:
+    tags: true
+    go: "1.11"

--- a/HACKING.md
+++ b/HACKING.md
@@ -80,9 +80,11 @@ problem or a bug in influx-spout.
 
 ## Releases
 
-Public releases of influx-spout are managed using
-[GoReleaser](https://goreleaser.com/). It must be installed on any
-host that is going to create and publish a release.
+Public releases of influx-spout are automatically created when a
+tagged revision successfully builds in [Travis CI](https://travis-ci.org/).
+[GoReleaser](https://goreleaser.com/) is used to create release
+tarbals and create a [release](https://github.com/jumptrading/influx-spout/releases)
+on Github.
 
 To publish a new release:
 
@@ -91,10 +93,9 @@ To publish a new release:
   level 1 header for the release (e.g. `# v3.2.1`). The
   `git log --reverse <previous-tag>..HEAD` command is useful for
   browsing the commits in the release.
-* Commit and merge the updates to `release-notes.md`.
+* Commit and merge the updates to `release-notes.md` to the `master`
+  branch on Github.
 * Create an annotated tag for the release. For example: `git tag v3.2.1 -m "3.2.1 release"`
 * Push the tag to Github. For example: `git push origin v3.2.1`
-* Publish the release using the Make target: `make goreleaser`
-
-This will build the release artifacts, generate a changelog and
-publish these to [Github](https://github.com/jumptrading/influx-spout/releases).
+* If the tagged revision builds successfully under Travis CI a release
+  should be automatically published to Github.


### PR DESCRIPTION
- Successful builds of tagged revisions should now cause release to be automatically be published to Github.
- Release instructions updated to match 
- Now testing and building with Go 1.10 and 1.11 (releases are created with 1.11).