### PR TITLE
Ensure listener never exceeds NATS maximum message size

### DIFF
--- a/batchsplitter/batch_splitter.go
+++ b/batchsplitter/batch_splitter.go
@@ -12,24 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package downsampler
+package batchsplitter
 
-// newBatchSplitter returns a batchSplitter which will efficiently
+// New returns a BatchSplitter which will efficiently
 // split BUF into chunks no larger than CHUNKSIZE with splits occuring
 // on newline boundaries.
 //
 // Use repeated calls to Next to generate the splits.
 //
 // Under no circumstances will chunks of more than chunkSize be
-// returned. If a line is larger than chunkSize, it will be broken up.
-func newBatchSplitter(buf []byte, chunkSize int) *batchSplitter {
-	return &batchSplitter{
+// returned. In the unlikely case of a line existing that is larger
+// than chunkSize, it will be broken up.
+func New(buf []byte, chunkSize int) *BatchSplitter {
+	return &BatchSplitter{
 		buf:       buf,
 		chunkSize: chunkSize,
 	}
 }
 
-type batchSplitter struct {
+// BatchSplitter which will efficiently split a byte slice into chunks
+// of no larger than some size with splits occuring on newline
+// boundaries.
+type BatchSplitter struct {
 	buf       []byte
 	chunkSize int
 	out       []byte
@@ -37,7 +41,7 @@ type batchSplitter struct {
 
 // Next scans for the next chunk, returning true if there was another
 // chunk to return. Use Chunk() to retrieve the bytes for the chunk.
-func (s *batchSplitter) Next() bool {
+func (s *BatchSplitter) Next() bool {
 	if len(s.buf) == 0 {
 		s.out = nil
 		return false
@@ -68,6 +72,6 @@ func (s *batchSplitter) Next() bool {
 
 // Chunk returns the chunk found by the last call to Next(). The
 // returned slice is only useful until the next call to Next().
-func (s *batchSplitter) Chunk() []byte {
+func (s *BatchSplitter) Chunk() []byte {
 	return s.out
 }

--- a/batchsplitter/batch_splitter.go
+++ b/batchsplitter/batch_splitter.go
@@ -14,6 +14,8 @@
 
 package batchsplitter
 
+import "github.com/c2h5oh/datasize"
+
 // New returns a BatchSplitter which will efficiently
 // split BUF into chunks no larger than CHUNKSIZE with splits occuring
 // on newline boundaries.
@@ -23,10 +25,10 @@ package batchsplitter
 // Under no circumstances will chunks of more than chunkSize be
 // returned. In the unlikely case of a line existing that is larger
 // than chunkSize, it will be broken up.
-func New(buf []byte, chunkSize int) *BatchSplitter {
+func New(buf []byte, chunkSize datasize.ByteSize) *BatchSplitter {
 	return &BatchSplitter{
 		buf:       buf,
-		chunkSize: chunkSize,
+		chunkSize: int(chunkSize),
 	}
 }
 

--- a/batchsplitter/batch_splitter_test.go
+++ b/batchsplitter/batch_splitter_test.go
@@ -14,17 +14,18 @@
 
 // +build small
 
-package downsampler
+package batchsplitter_test
 
 import (
 	"testing"
 
+	"github.com/jumptrading/influx-spout/batchsplitter"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestEmpty(t *testing.T) {
 	b := []byte("")
-	splitter := newBatchSplitter(b, 100)
+	splitter := batchsplitter.New(b, 100)
 
 	assert.False(t, splitter.Next())
 	assert.Nil(t, splitter.Chunk())
@@ -32,7 +33,7 @@ func TestEmpty(t *testing.T) {
 
 func TestNoSplit(t *testing.T) {
 	b := []byte("abcdefghij\n")
-	splitter := newBatchSplitter(b, 100)
+	splitter := batchsplitter.New(b, 100)
 
 	assert.True(t, splitter.Next())
 	assert.Equal(t, b, splitter.Chunk())
@@ -43,7 +44,7 @@ func TestNoSplit(t *testing.T) {
 
 func TestNoSplitWithLines(t *testing.T) {
 	b := []byte("abcd\nefg\nhij")
-	splitter := newBatchSplitter(b, 100)
+	splitter := batchsplitter.New(b, 100)
 
 	assert.True(t, splitter.Next())
 	assert.Equal(t, b, splitter.Chunk())
@@ -54,7 +55,7 @@ func TestNoSplitWithLines(t *testing.T) {
 
 func TestNoSplitExact(t *testing.T) {
 	b := []byte("abcd\nefg\nhij")
-	splitter := newBatchSplitter(b, len(b))
+	splitter := batchsplitter.New(b, len(b))
 
 	assert.True(t, splitter.Next())
 	assert.Equal(t, b, splitter.Chunk())
@@ -65,7 +66,7 @@ func TestNoSplitExact(t *testing.T) {
 
 func TestChunks(t *testing.T) {
 	b := []byte("1111\n2222\n333\n")
-	splitter := newBatchSplitter(b, 6)
+	splitter := batchsplitter.New(b, 6)
 
 	assert.True(t, splitter.Next())
 	assert.Equal(t, []byte("1111\n"), splitter.Chunk())
@@ -82,7 +83,7 @@ func TestChunks(t *testing.T) {
 
 func TestChunksExact(t *testing.T) {
 	b := []byte("1111\n2222\n3333\n")
-	splitter := newBatchSplitter(b, 5)
+	splitter := batchsplitter.New(b, 5)
 
 	assert.True(t, splitter.Next())
 	assert.Equal(t, []byte("1111\n"), splitter.Chunk())
@@ -99,7 +100,7 @@ func TestChunksExact(t *testing.T) {
 
 func TestLineTooLong(t *testing.T) {
 	b := []byte("01234567")
-	splitter := newBatchSplitter(b, 3)
+	splitter := batchsplitter.New(b, 3)
 
 	assert.True(t, splitter.Next())
 	assert.Equal(t, []byte("012"), splitter.Chunk())
@@ -116,7 +117,7 @@ func TestLineTooLong(t *testing.T) {
 
 func TestMultiLineTooLong(t *testing.T) {
 	b := []byte("0123456\n88\n99")
-	splitter := newBatchSplitter(b, 3)
+	splitter := batchsplitter.New(b, 3)
 
 	assert.True(t, splitter.Next())
 	assert.Equal(t, []byte("012"), splitter.Chunk())

--- a/batchsplitter/batch_splitter_test.go
+++ b/batchsplitter/batch_splitter_test.go
@@ -19,13 +19,14 @@ package batchsplitter_test
 import (
 	"testing"
 
+	"github.com/c2h5oh/datasize"
 	"github.com/jumptrading/influx-spout/batchsplitter"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestEmpty(t *testing.T) {
 	b := []byte("")
-	splitter := batchsplitter.New(b, 100)
+	splitter := batchsplitter.New(b, 100*datasize.B)
 
 	assert.False(t, splitter.Next())
 	assert.Nil(t, splitter.Chunk())
@@ -33,7 +34,7 @@ func TestEmpty(t *testing.T) {
 
 func TestNoSplit(t *testing.T) {
 	b := []byte("abcdefghij\n")
-	splitter := batchsplitter.New(b, 100)
+	splitter := batchsplitter.New(b, 100*datasize.B)
 
 	assert.True(t, splitter.Next())
 	assert.Equal(t, b, splitter.Chunk())
@@ -44,7 +45,7 @@ func TestNoSplit(t *testing.T) {
 
 func TestNoSplitWithLines(t *testing.T) {
 	b := []byte("abcd\nefg\nhij")
-	splitter := batchsplitter.New(b, 100)
+	splitter := batchsplitter.New(b, 100*datasize.B)
 
 	assert.True(t, splitter.Next())
 	assert.Equal(t, b, splitter.Chunk())
@@ -55,7 +56,7 @@ func TestNoSplitWithLines(t *testing.T) {
 
 func TestNoSplitExact(t *testing.T) {
 	b := []byte("abcd\nefg\nhij")
-	splitter := batchsplitter.New(b, len(b))
+	splitter := batchsplitter.New(b, datasize.ByteSize(len(b)))
 
 	assert.True(t, splitter.Next())
 	assert.Equal(t, b, splitter.Chunk())
@@ -66,7 +67,7 @@ func TestNoSplitExact(t *testing.T) {
 
 func TestChunks(t *testing.T) {
 	b := []byte("1111\n2222\n333\n")
-	splitter := batchsplitter.New(b, 6)
+	splitter := batchsplitter.New(b, 6*datasize.B)
 
 	assert.True(t, splitter.Next())
 	assert.Equal(t, []byte("1111\n"), splitter.Chunk())
@@ -83,7 +84,7 @@ func TestChunks(t *testing.T) {
 
 func TestChunksExact(t *testing.T) {
 	b := []byte("1111\n2222\n3333\n")
-	splitter := batchsplitter.New(b, 5)
+	splitter := batchsplitter.New(b, 5*datasize.B)
 
 	assert.True(t, splitter.Next())
 	assert.Equal(t, []byte("1111\n"), splitter.Chunk())
@@ -100,7 +101,7 @@ func TestChunksExact(t *testing.T) {
 
 func TestLineTooLong(t *testing.T) {
 	b := []byte("01234567")
-	splitter := batchsplitter.New(b, 3)
+	splitter := batchsplitter.New(b, 3*datasize.B)
 
 	assert.True(t, splitter.Next())
 	assert.Equal(t, []byte("012"), splitter.Chunk())
@@ -117,7 +118,7 @@ func TestLineTooLong(t *testing.T) {
 
 func TestMultiLineTooLong(t *testing.T) {
 	b := []byte("0123456\n88\n99")
-	splitter := batchsplitter.New(b, 3)
+	splitter := batchsplitter.New(b, 3*datasize.B)
 
 	assert.True(t, splitter.Next())
 	assert.Equal(t, []byte("012"), splitter.Chunk())

--- a/config/config.go
+++ b/config/config.go
@@ -129,6 +129,10 @@ func (c *Config) validateListener() error {
 	if len(c.NATSSubject) != 1 {
 		return errors.New("listener should only use one NATS subject")
 	}
+	if c.BatchMaxSize > datasize.MB {
+		// NATS can only accept messages up to 1MB in size.
+		return errors.New("listener batch must be 1MB or smaller")
+	}
 	return nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,9 @@ import (
 // line is then overlaid on top of it.
 const commonFileName = "/etc/influx-spout.toml"
 
+// MaxNATSMsgSize is the maximum size of message that NATS will accept.
+const MaxNATSMsgSize = datasize.MB
+
 // Config represents the configuration for a single influx-spout
 // component.
 type Config struct {
@@ -129,9 +132,8 @@ func (c *Config) validateListener() error {
 	if len(c.NATSSubject) != 1 {
 		return errors.New("listener should only use one NATS subject")
 	}
-	if c.BatchMaxSize > datasize.MB {
-		// NATS can only accept messages up to 1MB in size.
-		return errors.New("listener batch must be 1MB or smaller")
+	if c.BatchMaxSize > MaxNATSMsgSize {
+		return fmt.Errorf("listener batch must be %s or smaller", MaxNATSMsgSize)
 	}
 	return nil
 }

--- a/config/config_small_test.go
+++ b/config/config_small_test.go
@@ -373,6 +373,18 @@ mode = "listener_http"
 nats_subject = ["one", "two"]
 `,
 	}, {
+		"listener batch must be 1MB or smaller",
+		`
+mode = "listener"
+batch_max_size = 1048577
+`,
+	}, {
+		"listener batch must be 1MB or smaller",
+		`
+mode = "listener_http"
+batch_max_size = 1048577
+`,
+	}, {
 		"filter should only use one NATS subject",
 		`
 mode = "filter"

--- a/downsampler/downsampler.go
+++ b/downsampler/downsampler.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/nats-io/go-nats"
 
+	"github.com/jumptrading/influx-spout/batchsplitter"
 	"github.com/jumptrading/influx-spout/config"
 	"github.com/jumptrading/influx-spout/probes"
 	"github.com/jumptrading/influx-spout/stats"
@@ -168,7 +169,7 @@ func (ds *Downsampler) worker(subject string, inputCh <-chan []byte) {
 				log.Printf("publishing to %s (%d bytes)", outSubject, len(buf))
 			}
 
-			splitter := newBatchSplitter(buf, maxNATSMsgSize)
+			splitter := batchsplitter.New(buf, maxNATSMsgSize)
 			for splitter.Next() {
 				if err := ds.nc.Publish(outSubject, splitter.Chunk()); err != nil {
 					log.Printf("publish error for %s: %v", outSubject, err)

--- a/downsampler/downsampler.go
+++ b/downsampler/downsampler.go
@@ -28,8 +28,6 @@ import (
 	"github.com/jumptrading/influx-spout/stats"
 )
 
-const maxNATSMsgSize = 1024 * 1024
-
 const (
 	statReceived          = "received"
 	statSent              = "sent"
@@ -169,7 +167,7 @@ func (ds *Downsampler) worker(subject string, inputCh <-chan []byte) {
 				log.Printf("publishing to %s (%d bytes)", outSubject, len(buf))
 			}
 
-			splitter := batchsplitter.New(buf, maxNATSMsgSize)
+			splitter := batchsplitter.New(buf, config.MaxNATSMsgSize)
 			for splitter.Next() {
 				if err := ds.nc.Publish(outSubject, splitter.Chunk()); err != nil {
 					log.Printf("publish error for %s: %v", outSubject, err)

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -361,16 +361,9 @@ func (l *Listener) listenHTTP(server *http.Server) {
 }
 
 func (l *Listener) maybeSendBatch() {
-	if !l.shouldSend() {
-		return
+	if l.shouldSend() {
+		l.sendBatch()
 	}
-
-	l.stats.Inc(statSent)
-	if err := l.nc.Publish(l.c.NATSSubject[0], l.batch.Bytes()); err != nil {
-		l.stats.Inc(statFailedNATSPublish)
-		l.handleNatsError(err)
-	}
-	l.batch.Reset()
 }
 
 func (l *Listener) shouldSend() bool {

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/jumptrading/influx-spout/batch"
+	"github.com/jumptrading/influx-spout/batchsplitter"
 	"github.com/jumptrading/influx-spout/config"
 	"github.com/jumptrading/influx-spout/influx"
 	"github.com/jumptrading/influx-spout/probes"
@@ -391,9 +392,19 @@ func (l *Listener) sendBatch() {
 	}
 
 	l.stats.Inc(statSent)
-	if err := l.nc.Publish(l.c.NATSSubject[0], l.batch.Bytes()); err != nil {
-		l.stats.Inc(statFailedNATSPublish)
-		l.handleNatsError(err)
+
+	// The goal is for the batch size to never be bigger than what
+	// NATS will accept but there is a small chance that a series of
+	// large incoming chunks could cause the batch to grow beyond the
+	// intended limit. For these cases, use the batchsplitter just in
+	// case. batchsplitter has very low overhead when no splitting is
+	// required.
+	splitter := batchsplitter.New(l.batch.Bytes(), config.MaxNATSMsgSize)
+	for splitter.Next() {
+		if err := l.nc.Publish(l.c.NATSSubject[0], splitter.Chunk()); err != nil {
+			l.stats.Inc(statFailedNATSPublish)
+			l.handleNatsError(err)
+		}
 	}
 	l.batch.Reset()
 }


### PR DESCRIPTION
There are 2 aspects to this change:

1. listener config validation now fails if the listener batch size is configured to be more than 1MB.
2. In the case of a series of large incoming chunks the listener batch might still exceed the 1MB limit so use the BatchSplitter to ensure that batches emitted from the listener don't exceed the limit.

To support this change, the BatchSplitter has been extracted from the downsampler package into its own.

Fixes #119.