### PR TITLE
writer: Enforce maximum batch size

### DIFF
--- a/writer/writer.go
+++ b/writer/writer.go
@@ -28,6 +28,7 @@ import (
 	"github.com/nats-io/go-nats"
 
 	"github.com/jumptrading/influx-spout/batch"
+	"github.com/jumptrading/influx-spout/batchsplitter"
 	"github.com/jumptrading/influx-spout/config"
 	"github.com/jumptrading/influx-spout/filter"
 	"github.com/jumptrading/influx-spout/probes"
@@ -175,15 +176,25 @@ func (w *Writer) worker(jobs <-chan *nats.Msg) {
 		if w.shouldSend(batch) {
 			w.stats.Inc(statWriteRequests)
 
-			if err := dbClient.Write(batch.Bytes()); err != nil {
-				w.stats.Inc(statFailedWrites)
-				log.Printf("Error: %v", err)
-				if retryCh != nil {
-					// Copy the bytes because the underlying batch
-					// buffer will be reused. A copy is relatively
-					// expensive but is only made in the (hopefully)
-					// rare case of a retry.
-					retryCh <- batch.CopyBytes()
+			// It is possible for the batch to end up being slightly
+			// larger than the configured maximum batch size because
+			// inbound messages will almost never align exactly with
+			// the maximum batch size. Split up the batch if required.
+			splitter := batchsplitter.New(batch.Bytes(), w.c.BatchMaxSize)
+			for splitter.Next() {
+				chunk := splitter.Chunk()
+				if err := dbClient.Write(chunk); err != nil {
+					w.stats.Inc(statFailedWrites)
+					log.Printf("Error: %v", err)
+					if retryCh != nil {
+						// Copy the bytes because the underlying batch
+						// buffer will be reused. A copy is relatively
+						// expensive but is only made in the (hopefully)
+						// rare case of a retry.
+						retryChunk := make([]byte, len(chunk))
+						copy(retryChunk, chunk)
+						retryCh <- retryChunk
+					}
 				}
 			}
 


### PR DESCRIPTION
When writing a batch to InfluxDB it is possible for the batch size to
exceed the maximum batch size because incoming lines are unlikely to
exactly fit inside the desired batch size. A BatchSplitter is now used
to ensure that the configured batch size is never exceeded.

This is important because InfluxDB has a maximum body size that it
will accept.