### PR TITLE
Document metrics

### DIFF
--- a/cmd/influx-spout/e2e_large_test.go
+++ b/cmd/influx-spout/e2e_large_test.go
@@ -122,8 +122,6 @@ failed_writes{component="writer",host="h",influxdb_address="localhost",influxdb_
 invalid_lines{component="downsampler",host="h",name="downsampler"} 0
 invalid_timestamps{component="downsampler",host="h",name="downsampler"} 0
 invalid_time{component="filter",host="h",name="filter"} 0
-max_pending{component="writer",host="h",influxdb_address="localhost",influxdb_dbname="test",influxdb_port="44601",name="writer"} \d+
-max_pending{component="writer",host="h",influxdb_address="localhost",influxdb_dbname="test-archive",influxdb_port="44601",name="archive-writer"} \d+
 nats_dropped{component="downsampler",host="h",name="downsampler",subject="system"} 0
 nats_dropped{component="filter",host="h",name="filter"} 0
 nats_dropped{component="writer",host="h",influxdb_address="localhost",influxdb_dbname="test",influxdb_port="44601",name="writer",subject="system"} 0

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -40,7 +40,7 @@ const (
 
 // StartFilter creates a Filter instance, sets up its rules based on
 // the configuration give and sets up a subscription for the incoming
-// NATS topic.
+// NATS subject.
 func StartFilter(conf *config.Config) (_ *Filter, err error) {
 	f := &Filter{
 		c:      conf,

--- a/filter/rules.go
+++ b/filter/rules.go
@@ -24,8 +24,8 @@ import (
 	"github.com/jumptrading/influx-spout/influx"
 )
 
-// Rule encapsulates a matching function and the NATS topic to
-// send lines to if the rule matches.
+// Rule encapsulates a matching function and the NATS subject to send
+// lines to if the rule matches.
 type Rule struct {
 	// Function used to check if the rule matches
 	match func(*parsedLine) bool

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -39,7 +39,6 @@ const (
 	statReceived      = "received"
 	statWriteRequests = "write_requests"
 	statFailedWrites  = "failed_writes"
-	statMaxPending    = "max_pending"
 	statNATSDropped   = "nats_dropped"
 )
 
@@ -60,7 +59,7 @@ type Writer struct {
 func StartWriter(c *config.Config) (_ *Writer, err error) {
 	w := &Writer{
 		c:      c,
-		stats:  stats.New(statReceived, statWriteRequests, statFailedWrites, statMaxPending),
+		stats:  stats.New(statReceived, statWriteRequests, statFailedWrites),
 		probes: probes.Listen(c.ProbePort),
 		stop:   make(chan struct{}),
 	}


### PR DESCRIPTION
Document the metrics exposed by each influx-spout component. Also fixed a few minor issues discovered while writing these docs.

Closes #122.