### PR TITLE
influx: Faster Unescape implementation

### DIFF
--- a/influx/unescape_small_test.go
+++ b/influx/unescape_small_test.go
@@ -68,3 +68,14 @@ func TestUnescape(t *testing.T) {
 	check(`日\`, `日\`)
 	check(`hello\`, `hello\`)
 }
+
+var benchOut []byte
+
+func BenchmarkUnescape(b *testing.B) {
+	var x []byte
+	for i := 0; i < b.N; i++ {
+		x = Unescape([]byte("hello"))
+		x = Unescape([]byte(`foo\,\"\ \=bar`))
+	}
+	benchOut = x
+}


### PR DESCRIPTION
This is about 4% faster than the previous implementation.

Closes #120 