### PR TITLE
 listener: add newline to UDP read if missing

### DIFF
--- a/batch/batch.go
+++ b/batch/batch.go
@@ -99,15 +99,7 @@ func (b *Batch) Reset() {
 // Append adds some bytes to the Batch, growing the Batch if required.
 func (b *Batch) Append(more []byte) {
 	b.countWrite()
-
-	lenMore := len(more)
-	for b.Remaining() < lenMore {
-		b.grow()
-	}
-
-	lenBatch := len(b.buf)
-	b.buf = b.buf[:lenBatch+lenMore]
-	copy(b.buf[lenBatch:], more)
+	b.appendImpl(more)
 }
 
 // ReadFrom reads everything from an io.Reader, growing the Batch if
@@ -150,6 +142,26 @@ func (b *Batch) ReadOnceFrom(r io.Reader) (int, error) {
 		b.buf = b.buf[:len(b.buf)+n]
 	}
 	return n, err
+}
+
+// EnsureNewline adds a newline to the end of the batch if there
+// isn't one already present.
+func (b *Batch) EnsureNewline() {
+	n := len(b.buf)
+	if n > 0 && b.buf[n-1] != '\n' {
+		b.appendImpl([]byte{'\n'})
+	}
+}
+
+func (b *Batch) appendImpl(more []byte) {
+	lenMore := len(more)
+	for b.Remaining() < lenMore {
+		b.grow()
+	}
+
+	lenBatch := len(b.buf)
+	b.buf = b.buf[:lenBatch+lenMore]
+	copy(b.buf[lenBatch:], more)
 }
 
 // grow doubles the size of the Batch's internal buffer. This is

--- a/batch/batch_small_test.go
+++ b/batch/batch_small_test.go
@@ -125,6 +125,27 @@ func TestCopyBytes(t *testing.T) {
 	assert.Equal(t, []byte("foo"), b1)
 }
 
+func TestEnsureNewline(t *testing.T) {
+	b := New(64)
+
+	// Does nothing if batch is empty.
+	b.EnsureNewline()
+	assert.Equal(t, []byte{}, b.Bytes())
+
+	// Newline added if needed.
+	b.Append([]byte("foo"))
+	b.EnsureNewline()
+	assert.Equal(t, []byte("foo\n"), b.Bytes())
+
+	// No newline added if not required.
+	b.Append([]byte("bar\n"))
+	b.EnsureNewline()
+	assert.Equal(t, []byte("foo\nbar\n"), b.Bytes())
+
+	// Addition of newlines shouldn't contribute to write count.
+	assert.Equal(t, 2, b.Writes())
+}
+
 func TestAge(t *testing.T) {
 	// Batch shouldn't age if there's no data in it.
 	b := New(10)

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -198,6 +198,7 @@ func (l *Listener) listenUDP(sc *net.UDPConn) {
 				log.Printf("listener read %d bytes", bytesRead)
 			}
 			l.stats.Inc(statReceived)
+			l.batch.EnsureNewline()
 		}
 
 		l.maybeSendBatch()


### PR DESCRIPTION
The sender is supposed to add include a newline terminator to each line sent but sometimes the final newline is missed.