### PR TITLE
batch: Write count shouldn't increment count when no data

### DIFF
--- a/batch/batch.go
+++ b/batch/batch.go
@@ -128,9 +128,8 @@ func (b *Batch) ReadFrom(r io.Reader) (int64, error) {
 
 // ReadOnceFrom reads into the Batch just once from an io.Reader.
 func (b *Batch) ReadOnceFrom(r io.Reader) (int, error) {
-	b.countWrite()
 	b.growIfLow()
-  n, err := r.Read(b.buf[len(b.buf):cap(b.buf)])
+        n, err := r.Read(b.buf[len(b.buf):cap(b.buf)])
 	if n > 0 {
 		b.buf = b.buf[:len(b.buf)+n]
 		b.countWrite()

--- a/batch/batch.go
+++ b/batch/batch.go
@@ -113,8 +113,6 @@ func (b *Batch) Append(more []byte) {
 // ReadFrom reads everything from an io.Reader, growing the Batch if
 // required.
 func (b *Batch) ReadFrom(r io.Reader) (int64, error) {
-	b.countWrite()
-
 	var total int64
 	for {
 		// If there's not much capacity left, grow the buffer.
@@ -128,6 +126,9 @@ func (b *Batch) ReadFrom(r io.Reader) (int64, error) {
 		}
 
 		if err != nil {
+			if total > 0 {
+				b.countWrite()
+			}
 			if err == io.EOF {
 				err = nil
 			}
@@ -138,8 +139,6 @@ func (b *Batch) ReadFrom(r io.Reader) (int64, error) {
 
 // ReadOnceFrom reads into the Batch just once from an io.Reader.
 func (b *Batch) ReadOnceFrom(r io.Reader) (int, error) {
-	b.countWrite()
-
 	// If there's not much capacity left, grow the buffer.
 	if b.Remaining() <= minReadSize {
 		b.grow()
@@ -148,6 +147,10 @@ func (b *Batch) ReadOnceFrom(r io.Reader) (int, error) {
 	n, err := r.Read(b.buf[len(b.buf):cap(b.buf)])
 	if n > 0 {
 		b.buf = b.buf[:len(b.buf)+n]
+		b.countWrite()
+	}
+	if err == io.EOF {
+		err = nil
 	}
 	return n, err
 }


### PR DESCRIPTION
ReadFrom and ReadOnceFrom would both increment the write count when no data was read from the source. For the UDP listener especially this would cause batches to get sent on sooner than intended.