### PR TITLE
batch: Grow by at least max UDP packet size

### DIFF
--- a/batch/batch_small_test.go
+++ b/batch/batch_small_test.go
@@ -54,15 +54,17 @@ func TestAppend(t *testing.T) {
 func TestAppendGrow(t *testing.T) {
 	b := New(2) // only 2 bytes!
 
-	b.Append([]byte("foo")) // add 3 bytes of data to cause growth
+	// Add 3 bytes of data to cause growth.
+	b.Append([]byte("foo"))
 	assert.Equal(t, 3, b.Size())
-	assert.Equal(t, 1, b.Remaining())
+	assert.Equal(t, maxReadSize+2-3, b.Remaining())
 	assert.Equal(t, 1, b.Writes())
 	assert.Equal(t, []byte("foo"), b.Bytes())
 
-	b.Append([]byte("bar")) // add another 3 bytes of data to cause growth again
+	// Add another 3 bytes of data (no growth)
+	b.Append([]byte("bar"))
 	assert.Equal(t, 6, b.Size())
-	assert.Equal(t, 2, b.Remaining())
+	assert.Equal(t, maxReadSize-4, b.Remaining())
 	assert.Equal(t, 2, b.Writes())
 	assert.Equal(t, []byte("foobar"), b.Bytes())
 }
@@ -75,7 +77,7 @@ func TestReadFrom(t *testing.T) {
 	assert.Equal(t, int64(3), count)
 
 	assert.Equal(t, 3, b.Size())
-	assert.Equal(t, 37, b.Remaining())
+	assert.Equal(t, maxReadSize+10-3, b.Remaining())
 	assert.Equal(t, 1, b.Writes())
 	assert.Equal(t, []byte("foo"), b.Bytes())
 }
@@ -88,7 +90,7 @@ func TestReadOnceFrom(t *testing.T) {
 	assert.Equal(t, 3, count)
 
 	assert.Equal(t, 3, b.Size())
-	assert.Equal(t, 17, b.Remaining())
+	assert.Equal(t, maxReadSize+10-3, b.Remaining())
 	assert.Equal(t, 1, b.Writes())
 	assert.Equal(t, []byte("foo"), b.Bytes())
 }


### PR DESCRIPTION
The batch buffer was only being grown when there were less than 1024
bytes remaining. This was problematic in ReadOnceFrom where there
could be up to 64KB available to read (from a UDP socket), and could
result in incomplete reads.

The batch is now grown when there's less than 64KB available in the
buffer. The batch is now always grown by at least 64KB (in case a very
small batch size is configured).