### PR TITLE
More escaping fixes

### DIFF
--- a/downsampler/avgbucket.go
+++ b/downsampler/avgbucket.go
@@ -43,7 +43,7 @@ func (b *avgBucket) EndTime() time.Time {
 
 func (b *avgBucket) AddLine(line []byte) (errs []error) {
 	var keyBytes []byte
-	keyBytes, line = influx.Token(line, []byte(" "), false) // key = measurement + tags
+	keyBytes, line = influx.TokenEscaped(line, []byte(" ")) // key = measurement + tags
 	key := string(keyBytes)
 
 	// Assumption: tags are already ordered (filter does this).
@@ -98,7 +98,7 @@ func (fp *fieldPairs) update(raw []byte) (errs []error) {
 		}
 		raw = raw[1:] // remove leading comma or space
 		var nameBytes []byte
-		nameBytes, raw = influx.Token(raw, []byte("="), true)
+		nameBytes, raw = influx.Token(raw, []byte("="))
 		if len(raw) == 0 || raw[0] != '=' {
 			errs = append(errs, errors.New("invalid field"))
 			return
@@ -130,7 +130,7 @@ func (fp *fieldPairs) update(raw []byte) (errs []error) {
 			}
 		} else {
 			// Other field
-			rawValue, raw = influx.Token(raw, []byte{','}, true)
+			rawValue, raw = influx.Token(raw, []byte{','})
 			value, exists := fp.fields[name]
 			if !exists {
 				fp.fields[name] = newFieldValue(rawValue)

--- a/downsampler/avgbucket.go
+++ b/downsampler/avgbucket.go
@@ -98,7 +98,7 @@ func (fp *fieldPairs) update(raw []byte) (errs []error) {
 		}
 		raw = raw[1:] // remove leading comma or space
 		var nameBytes []byte
-		nameBytes, raw = influx.Token(raw, []byte("="))
+		nameBytes, raw = influx.TokenEscaped(raw, []byte("="))
 		if len(raw) == 0 || raw[0] != '=' {
 			errs = append(errs, errors.New("invalid field"))
 			return

--- a/downsampler/avgbucket_small_test.go
+++ b/downsampler/avgbucket_small_test.go
@@ -204,6 +204,13 @@ func TestEscapingInTags(t *testing.T) {
 	assertBytes(t, `foo,ab\ cd=ef\=gh bar=123i`, b.Bytes())
 }
 
+func TestEscapingInFieldName(t *testing.T) {
+	b := newAvgBucket(now)
+
+	require.Nil(t, b.AddLine([]byte(`foo ab\ cd=123i`)))
+	assertBytes(t, `foo ab\ cd=123i`, b.Bytes())
+}
+
 func TestInvalidField(t *testing.T) {
 	b := newAvgBucket(now)
 	errs := b.AddLine([]byte(`foo x`))

--- a/downsampler/avgbucket_small_test.go
+++ b/downsampler/avgbucket_small_test.go
@@ -190,6 +190,20 @@ func TestMeasurementAndTagsOnly(t *testing.T) {
 	), b.Bytes())
 }
 
+func TestEscapingInMeasurement(t *testing.T) {
+	b := newAvgBucket(now)
+
+	require.Nil(t, b.AddLine([]byte(`fo\,o bar=1i`)))
+	assertBytes(t, `fo\,o bar=1i`, b.Bytes())
+}
+
+func TestEscapingInTags(t *testing.T) {
+	b := newAvgBucket(now)
+
+	require.Nil(t, b.AddLine([]byte(`foo,ab\ cd=ef\=gh bar=123i`)))
+	assertBytes(t, `foo,ab\ cd=ef\=gh bar=123i`, b.Bytes())
+}
+
 func TestInvalidField(t *testing.T) {
 	b := newAvgBucket(now)
 	errs := b.AddLine([]byte(`foo x`))

--- a/influx/tags.go
+++ b/influx/tags.go
@@ -97,7 +97,7 @@ func (t TagSet) Bytes() []byte {
 // also returned unchanged. Errors are returned if incorrectly
 // formatted tags are present in the line.
 func ParseTags(line []byte) ([]byte, TagSet, []byte, error) {
-	measurement, line := Token(line, []byte(", "), true)
+	measurement, line := Token(line, []byte(", "))
 
 	if len(line) == 0 {
 		// Measurement without anything else.
@@ -114,12 +114,12 @@ func ParseTags(line []byte) ([]byte, TagSet, []byte, error) {
 			return measurement, tags, line[1:], nil
 		}
 
-		key, line = Token(line[1:], []byte("= ,"), true)
+		key, line = Token(line[1:], []byte("= ,"))
 		if len(line) == 0 || line[0] != '=' {
 			return nil, nil, nil, errors.New("invalid tag")
 		}
 
-		value, line = Token(line[1:], []byte(", "), true)
+		value, line = Token(line[1:], []byte(", "))
 		if len(value) == 0 {
 			return nil, nil, nil, errors.New("invalid tag")
 		}

--- a/influx/token_small_test.go
+++ b/influx/token_small_test.go
@@ -24,33 +24,42 @@ import (
 )
 
 func TestToken(t *testing.T) {
-	check := func(input, until, exp, expRemainder string, unescape bool) {
-		actual, actualRemainder := Token([]byte(input), []byte(until), unescape)
+	check := func(input, until, exp, expRemainder string) {
+		actual, actualRemainder := Token([]byte(input), []byte(until))
 		assert.Equal(t, exp, string(actual), "Token(%q, %q)", input, until)
 		assert.Equal(t, expRemainder, string(actualRemainder), "Token(%q, %q) (remainder)", input, until)
 	}
 
-	check("", " ", "", "", true)
-	check(`a`, " ", `a`, "", true)
-	check("日", " ", "日", "", true)
-	check(`hello`, " ", `hello`, "", true)
-	check("日本語", " ", "日本語", "", true)
-	check(" ", ", ", "", " ", true)
-	check(",", ", ", "", ",", true)
-	check(`h world`, ", ", `h`, " world", true)
-	check(`h,world`, ", ", `h`, ",world", true)
-	check(`hello world`, ", ", `hello`, ` world`, true)
-	check(`hello,world`, ", ", `hello`, `,world`, true)
-	check(`hello\ world more`, ", ", `hello world`, ` more`, true)
-	check(`hello\,world,more`, ", ", `hello,world`, `,more`, true)
-	check(`hello\ world more`, ", ", `hello\ world`, ` more`, false)
-	check(`hello\,world,more`, ", ", `hello\,world`, `,more`, false)
-	check(`hello\ 日本語 more`, ", ", `hello 日本語`, ` more`, true)
-	check(`hello\,日本語,more`, ", ", `hello,日本語`, `,more`, true)
-	check(`\ `, " ", " ", "", true)
-	check(`\ `, " ", `\ `, "", false)
-	check(`\`, " ", `\`, "", true)
-	check(`hello\`, " ", `hello\`, "", true)
+	check("", " ", "", "")
+	check(`a`, " ", `a`, "")
+	check("日", " ", "日", "")
+	check(`hello`, " ", `hello`, "")
+	check("日本語", " ", "日本語", "")
+	check(" ", ", ", "", " ")
+	check(",", ", ", "", ",")
+	check(`h world`, ", ", `h`, " world")
+	check(`h,world`, ", ", `h`, ",world")
+	check(`hello world`, ", ", `hello`, ` world`)
+	check(`hello,world`, ", ", `hello`, `,world`)
+	check(`hello\ world more`, ", ", `hello world`, ` more`)
+	check(`hello\,world,more`, ", ", `hello,world`, `,more`)
+	check(`hello\ 日本語 more`, ", ", `hello 日本語`, ` more`)
+	check(`hello\,日本語,more`, ", ", `hello,日本語`, `,more`)
+	check(`\ `, " ", " ", "")
+	check(`\`, " ", `\`, "")
+	check(`hello\`, " ", `hello\`, "")
+}
+
+func TestTokenEscaped(t *testing.T) {
+	check := func(input, until, exp, expRemainder string) {
+		actual, actualRemainder := TokenEscaped([]byte(input), []byte(until))
+		assert.Equal(t, exp, string(actual), "TokenEscaped(%q, %q)", input, until)
+		assert.Equal(t, expRemainder, string(actualRemainder), "TokenEscaped(%q, %q) (remainder)", input, until)
+	}
+
+	check(`hello\ world more`, ", ", `hello\ world`, ` more`)
+	check(`hello\,world,more`, ", ", `hello\,world`, `,more`)
+	check(`\ `, " ", `\ `, "")
 }
 
 func TestQuotedString(t *testing.T) {


### PR DESCRIPTION
A few things here:

* Instead of having Token take a boolean to control unescape handling, have a separate `TokenEscaped`  function. This leads to clearer and less errorprone code (no guessing what the boolean does).
* Fix the downsampler's handling of escaping in field keys. Field keys were being emitted unescaped when escaping was required. This is similar to the fix in #137.
* Extend test coverage for downsampler escape handling