### PR TITLE
Release tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,7 +151,12 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.gitignore.io/api/c,go,c++,linux,macos,windows
+
 *.bench
 /slowinfluxd
 /cmd/benchcheck/benchcheck
 /dist/
+
+# Files generated due to release deploys
+/do-goreleaser
+/latest-release-notes.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - "1.10.4"
-  - "1.11"
+  - "1.10.5"
+  - "1.11.2"
   - "master"  # find out if an upcoming change in Go is going to break us
 
 matrix:
@@ -35,4 +35,4 @@ deploy:
   script: make release
   on:
     tags: true
-    go: "1.11"
+    go: "1.11.2"

--- a/HACKING.md
+++ b/HACKING.md
@@ -95,7 +95,7 @@ To publish a new release:
   browsing the commits in the release.
 * Commit and merge the updates to `release-notes.md` to the `master`
   branch on Github.
-* Create an annotated tag for the release. For example: `git tag v3.2.1 -m "3.2.1 release"`
+* Create an annotated tag for the release. For example: `git tag -a v3.2.1 -m "3.2.1 release"`
 * Push the tag to Github. For example: `git push origin v3.2.1`
 * If the tagged revision builds successfully under Travis CI a release
   should be automatically published to Github.


### PR DESCRIPTION
* Release instructions: use annotated tag. The example command was incorrect.
* Bump Go versions to test with
* Git ignore files which are generated during release deploys