### PR TITLE
Build influx-spout in docker, using the multistage pattern. Addresses…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,21 @@
 ##Build influx-spout
 FROM golang:1 as go-builder
-WORKDIR /go/src/app
+WORKDIR /go/src/github.com/jumptrading/influx-spout
+
+#Obtaining source (choose 1)
 RUN ["bash", "-c", "git clone --depth=1 https://github.com/jumptrading/influx-spout.git ."]
+#Alternatively, you can change to use local source (example is this directory), with;
+#COPY ./ ./
+
+#Build
 RUN ["bash", "-c", "make deps influx-spout influx-spout-tap"]
 
 ##Use binaries and config in alpine production container
 FROM alpine:3
-COPY --from=go-builder /go/src/app/influx-spout /bin/
-COPY --from=go-builder /go/src/app/influx-spout-tap /bin/
-COPY --from=go-builder /go/src/app/example-udp-listener.conf /etc/influx-spout/udp-listener.toml
-COPY --from=go-builder /go/src/app/example-http-listener.conf /etc/influx-spout/http-listener.toml
+COPY --from=go-builder /go/src/github.com/jumptrading/influx-spout/influx-spout /bin/
+COPY --from=go-builder /go/src/github.com/jumptrading/influx-spout/influx-spout-tap /bin/
+COPY --from=go-builder /go/src/github.com/jumptrading/influx-spout/example-udp-listener.conf /etc/influx-spout/udp-listener.toml
+COPY --from=go-builder /go/src/github.com/jumptrading/influx-spout/example-http-listener.conf /etc/influx-spout/http-listener.toml
 RUN apk update && apk add dumb-init && rm -rf /var/cache/apk/*
 
 # Allow influx-spout to receive signals

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,18 @@
-FROM alpine:3.7
-ADD influx-spout /bin/
-ADD influx-spout-tap /bin/
-ADD example-udp-listener.conf /etc/influx-spout/udp-listener.toml
-ADD example-http-listener.conf /etc/influx-spout/http-listener.toml
+##Build influx-spout
+FROM golang:1 as go-builder
+WORKDIR /go/src/app
+RUN ["bash", "-c", "git clone --depth=1 https://github.com/jumptrading/influx-spout.git ."]
+RUN ["bash", "-c", "make deps influx-spout influx-spout-tap"]
+
+##Use binaries and config in alpine production container
+FROM alpine:3
+COPY --from=go-builder /go/src/app/influx-spout /bin/
+COPY --from=go-builder /go/src/app/influx-spout-tap /bin/
+COPY --from=go-builder /go/src/app/example-udp-listener.conf /etc/influx-spout/udp-listener.toml
+COPY --from=go-builder /go/src/app/example-http-listener.conf /etc/influx-spout/http-listener.toml
 RUN apk update && apk add dumb-init && rm -rf /var/cache/apk/*
 
 # Allow influx-spout to receive signals
 ENTRYPOINT ["/usr/bin/dumb-init", "--", "/bin/influx-spout"]
 CMD ["/etc/influx-spout/http-listener.toml"]
+


### PR DESCRIPTION
… #142.

This pull request;
- Builds the solution using the golang:1 container.
- Uses the artifacts similarly to before, to populate a lightweight alpine container for production use.

Note that make is not performing 'make check-git', because;
- The git source will not be modified in the container (as it's only performing clone)
- 'deps' will modify Gopkg.lock where needed to address ever changing dependencies, resulting in unstaged changes.