### PR TITLE
Add configuration switch for InfluxDB Writer via http and https

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,9 @@ nats_subject = ["influx-spout"]
 # Address of the InfluxDB instance to write to.
 influxdb_address = "localhost"
 
+# Protocol of the InfluxDB instance to write to (http/https).
+influxdb_protocol = "http"
+
 # TCP port where the InfluxDB backend can be found.
 influxdb_port = 8086
 

--- a/config/config.go
+++ b/config/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	NATSSubjectMonitor  string            `toml:"nats_subject_monitor"`
 	NATSSubjectJunkyard string            `toml:"nats_subject_junkyard"`
 	InfluxDBAddress     string            `toml:"influxdb_address"`
+	InfluxDBProtocol    string            `toml:"influxdb_protocol"`
 	InfluxDBPort        int               `toml:"influxdb_port"`
 	InfluxDBUser        string            `toml:"-"`
 	InfluxDBPass        string            `toml:"-"`
@@ -83,6 +84,7 @@ func newDefaultConfig() *Config {
 		NATSSubjectMonitor:  "influx-spout-monitor",
 		NATSSubjectJunkyard: "influx-spout-junk",
 		InfluxDBAddress:     "localhost",
+		InfluxDBProtocol:    "http",
 		InfluxDBPort:        8086,
 		DBName:              "influx-spout-junk",
 		BatchMaxCount:       10,
@@ -196,6 +198,9 @@ func (c *Config) validateWriter() error {
 	}
 	if c.InfluxDBPort < 1 || c.InfluxDBPort > 65535 {
 		return errors.New("influxdb_port out of range")
+	}
+	if c.InfluxDBProtocol != "http" && c.InfluxDBProtocol != "https" {
+                return errors.New("influxdb_protocol can only be http or https")
 	}
 	if c.InfluxDBUser != "" && c.InfluxDBPass == "" {
 		return errors.New("$INFLUXDB_USER without $INFLUXDB_PASS")

--- a/config/config_small_test.go
+++ b/config/config_small_test.go
@@ -51,7 +51,7 @@ nats_subject = ["spout"]
 nats_subject_monitor = "spout-monitor"
 
 influxdb_address = "localhost"
-influxdb_protocol = "http"
+influxdb_protocol = "https"
 influxdb_port = 8086
 influxdb_dbname = "junk_nats"
 
@@ -191,16 +191,6 @@ func TestInfluxAuth(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "user", conf.InfluxDBUser)
 	assert.Equal(t, "secret", conf.InfluxDBPass)
-}
-
-func TestInfluxHttps(t *testing.T) {
-	const influxHttps = `
-mode = "writer"
-influxdb_protocol = "https"
-`
-	conf, err := parseConfig(influxHttps)
-	require.NoError(t, err, "config should be parsed")
-	assert.Equal(t, "https", conf.InfluxDBProtocol)
 }
 
 func TestNoMode(t *testing.T) {

--- a/config/config_small_test.go
+++ b/config/config_small_test.go
@@ -51,6 +51,7 @@ nats_subject = ["spout"]
 nats_subject_monitor = "spout-monitor"
 
 influxdb_address = "localhost"
+influxdb_protocol = "http"
 influxdb_port = 8086
 influxdb_dbname = "junk_nats"
 
@@ -96,6 +97,7 @@ pprof_port = 5432
 	assert.Equal(t, 8086, conf.InfluxDBPort, "InfluxDB Port must match")
 	assert.Equal(t, "junk_nats", conf.DBName, "InfluxDB DBname must match")
 	assert.Equal(t, "localhost", conf.InfluxDBAddress, "InfluxDB address must match")
+	assert.Equal(t, "http", conf.InfluxDBProtocol, "InfluxDB protocol must match")
 
 	assert.Equal(t, "spout", conf.NATSSubject[0], "Subject must match")
 	assert.Equal(t, "spout-monitor", conf.NATSSubjectMonitor, "Monitor subject must match")
@@ -116,6 +118,7 @@ func TestAllDefaults(t *testing.T) {
 	assert.Equal(t, "influx-spout-monitor", conf.NATSSubjectMonitor)
 	assert.Equal(t, "influx-spout-junk", conf.NATSSubjectJunkyard)
 	assert.Equal(t, "localhost", conf.InfluxDBAddress)
+	assert.Equal(t, "http", conf.InfluxDBProtocol)
 	assert.Equal(t, 8086, conf.InfluxDBPort)
 	assert.Equal(t, "", conf.InfluxDBUser)
 	assert.Equal(t, "", conf.InfluxDBPass)
@@ -188,6 +191,16 @@ func TestInfluxAuth(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "user", conf.InfluxDBUser)
 	assert.Equal(t, "secret", conf.InfluxDBPass)
+}
+
+func TestInfluxHttps(t *testing.T) {
+	const influxHttps = `
+mode = "writer"
+influxdb_protocol = "https"
+`
+	conf, err := parseConfig(influxHttps)
+	require.NoError(t, err, "config should be parsed")
+	assert.Equal(t, "https", conf.InfluxDBProtocol)
 }
 
 func TestNoMode(t *testing.T) {
@@ -495,6 +508,12 @@ subject = "out"
 		`
 mode = "writer"
 nats_subject = []
+`,
+	}, {
+		"influxdb_protocol can only be http or https",
+		`
+mode = "writer"
+influxdb_protocol = "foo"
 `,
 	}, {
 		"influxdb_port out of range",

--- a/config/config_small_test.go
+++ b/config/config_small_test.go
@@ -97,7 +97,7 @@ pprof_port = 5432
 	assert.Equal(t, 8086, conf.InfluxDBPort, "InfluxDB Port must match")
 	assert.Equal(t, "junk_nats", conf.DBName, "InfluxDB DBname must match")
 	assert.Equal(t, "localhost", conf.InfluxDBAddress, "InfluxDB address must match")
-	assert.Equal(t, "http", conf.InfluxDBProtocol, "InfluxDB protocol must match")
+	assert.Equal(t, "https", conf.InfluxDBProtocol, "InfluxDB protocol must match")
 
 	assert.Equal(t, "spout", conf.NATSSubject[0], "Subject must match")
 	assert.Equal(t, "spout-monitor", conf.NATSSubjectMonitor, "Monitor subject must match")

--- a/writer/influxclient.go
+++ b/writer/influxclient.go
@@ -26,7 +26,7 @@ import (
 
 func newInfluxClient(c *config.Config) *influxClient {
 	return &influxClient{
-		url:      fmt.Sprintf("http://%s:%d/write?db=%s", c.InfluxDBAddress, c.InfluxDBPort, c.DBName),
+		url:      fmt.Sprintf("%s://%s:%d/write?db=%s", c.InfluxDBProtocol, c.InfluxDBAddress, c.InfluxDBPort, c.DBName),
 		username: c.InfluxDBUser,
 		password: c.InfluxDBPass,
 		debug:    c.Debug,

--- a/writer/writer_medium_test.go
+++ b/writer/writer_medium_test.go
@@ -49,6 +49,7 @@ func testConfig() *config.Config {
 		NATSSubject:        []string{"writer-test"},
 		NATSSubjectMonitor: "writer-test-monitor",
 		InfluxDBAddress:    "localhost",
+		InfluxDBProtocol:   "http",
 		InfluxDBPort:       influxPort,
 		DBName:             "metrics",
 		BatchMaxCount:      1,


### PR DESCRIPTION
Aims to address #145 .

The golang net/http client already supports https, so it does not seem that additional work would be needed there.
This simple and optional configuration setting adds https capability.